### PR TITLE
Update clause_join.hpp

### DIFF
--- a/apple/WCDB/abstract/clause_join.hpp
+++ b/apple/WCDB/abstract/clause_join.hpp
@@ -35,7 +35,8 @@ public:
         Inner,
         Cross,
     };
-
+    JoinClause():Describable(""){}
+    JoinClause(const std::string &tabelName):Describable(tabelName){}
     JoinClause &join(const Subquery &subquery,
                      JoinClause::Type type = JoinClause::Type::NotSet,
                      bool isNatural = false);


### PR DESCRIPTION
add construct function for JoinClause;
cause of this case:

```
StatementSelect state;
ColumnResultList retList;
retList.push_back(ColumnResult(Column::Any));
JoinClause joinOn("table1");
joinOn.join(Subquery("table2"), JoinClause::Type::Inner).on(Expr(Column("column1"))==Expr(Column("column2")));
normalState.select(retList).from(joinOn);
```