### PR TITLE
Use `isEmpty` over `comparing count to zero`

### DIFF
--- a/swift/source/builtin/CodableType.swift
+++ b/swift/source/builtin/CodableType.swift
@@ -254,7 +254,7 @@ extension ColumnJSONEncodable {
 public protocol ColumnJSONDecodable: ColumnDecodable where FundamentalType == Data {}
 extension ColumnJSONDecodable {
     public init?(with value: FundamentalType) {
-        guard value.count > 0 else {
+        guard !value.isEmpty else {
             return nil
         }
         guard let object = try? JSONDecoder().decode(Self.self, from: value) else {

--- a/swift/source/core/fts/WCDBTokenize.swift
+++ b/swift/source/core/fts/WCDBTokenize.swift
@@ -171,7 +171,7 @@ public final class WCDBCursorInfo: CursorInfoBase {
                                         stop = true
         })
         guard let lemma = optionalLemma,
-            lemma.count > 0,
+            !lemma.isEmpty,
             lemma.caseInsensitiveCompare(string) != ComparisonResult.orderedSame else {
             return SQLITE_OK
         }

--- a/swift/source/core/interface/Delete.swift
+++ b/swift/source/core/interface/Delete.swift
@@ -30,7 +30,7 @@ public final class Delete {
     public var changes: Int?
 
     internal init(with core: Core, andTableName tableName: String) throws {
-        guard tableName.count > 0 else {
+        guard !tableName.isEmpty else {
             throw Error.reportInterface(tag: core.tag,
                                         path: core.path,
                                         operation: .delete,

--- a/swift/source/core/interface/Insert.swift
+++ b/swift/source/core/interface/Insert.swift
@@ -31,7 +31,7 @@ public final class Insert {
                   named name: String,
                   on propertyConvertibleList: [PropertyConvertible]?,
                   isReplace: Bool = false) throws {
-        guard name.count > 0 else {
+        guard !name.isEmpty else {
             throw Error.reportInterface(tag: core.tag,
                                         path: core.path,
                                         operation: .insert,
@@ -71,7 +71,7 @@ public final class Insert {
     /// - Parameter objects: Object to be inserted
     /// - Throws: Error
     public func execute<Object: TableEncodable>(with objects: [Object]) throws {
-        guard objects.count > 0 else {
+        guard !objects.isEmpty else {
             Error.warning("Inserting with an empty/nil object")
             return
         }

--- a/swift/source/core/interface/MultiSelect.swift
+++ b/swift/source/core/interface/MultiSelect.swift
@@ -28,14 +28,14 @@ public final class MultiSelect: Selectable {
                   on propertyConvertibleList: [PropertyConvertible],
                   tables: [String],
                   isDistinct: Bool = false) throws {
-        guard propertyConvertibleList.count > 0 else {
+        guard !propertyConvertibleList.isEmpty else {
             throw Error.reportInterface(tag: core.tag,
                                         path: core.path,
                                         operation: .select,
                                         code: .misuse,
                                         message: "Selecting nothing from \(tables) is invalid")
         }
-        guard tables.count > 0 else {
+        guard !tables.isEmpty else {
             throw Error.reportInterface(tag: core.tag,
                                         path: core.path,
                                         operation: .select,

--- a/swift/source/core/interface/RowSelect.swift
+++ b/swift/source/core/interface/RowSelect.swift
@@ -26,7 +26,7 @@ public final class RowSelect: Selectable {
                   results columnResultConvertibleList: [ColumnResultConvertible],
                   tables: [String],
                   isDistinct: Bool) throws {
-        guard tables.count > 0 else {
+        guard !tables.isEmpty else {
             throw Error.reportInterface(tag: core.tag,
                                         path: core.path,
                                         operation: .select,

--- a/swift/source/core/interface/Update.swift
+++ b/swift/source/core/interface/Update.swift
@@ -31,14 +31,14 @@ public final class Update {
     public var changes: Int?
 
     internal init(with core: Core, on propertyConvertibleList: [PropertyConvertible], andTable table: String) throws {
-        guard propertyConvertibleList.count > 0 else {
+        guard !propertyConvertibleList.isEmpty else {
             throw Error.reportInterface(tag: core.tag,
                                         path: core.path,
                                         operation: .update,
                                         code: .misuse,
                                         message: "Updating \(table) with empty property")
         }
-        guard table.count > 0 else {
+        guard !table.isEmpty else {
             throw Error.reportInterface(tag: core.tag,
                                         path: core.path,
                                         operation: .update,


### PR DESCRIPTION
  >  To check whether a collection is empty, use its `isEmpty` property
    instead of comparing `count` to zero. Unless the collection guarantees
     random-access performance, calculating `count` can be an O(*n*)
    operation.

