### PR TITLE
[Feature] Make function param `table` RawPresentable

### DIFF
--- a/swift/source/abstract/Column.swift
+++ b/swift/source/abstract/Column.swift
@@ -30,6 +30,11 @@ public struct Column: Describable {
         description = name
     }
 
+    public func `in`<T>(table: T) -> Column
+        where T : RawRepresentable, T.RawValue == String {
+        return self.in(table: table.rawValue)
+    }
+
     public func `in`(table: String) -> Column {
         return Column(named: "\(table).\(description)")
     }

--- a/swift/source/abstract/Convertible.swift
+++ b/swift/source/abstract/Convertible.swift
@@ -91,6 +91,11 @@ extension ColumnConvertible {
         return ColumnDef(with: self, and: columnType)
     }
 
+    public func `in`<T>(table: T) -> Column
+        where T : RawRepresentable, T.RawValue == String {
+        return self.in(table: table.rawValue)
+    }
+
     public func `in`(table: String) -> Column {
         return asColumn().in(table: table)
     }

--- a/swift/source/abstract/ForeignKey.swift
+++ b/swift/source/abstract/ForeignKey.swift
@@ -34,6 +34,10 @@ public final class ForeignKey: Describable {
         self.init(withForeignTable: table, and: columnConvertibleList)
     }
 
+    public convenience init<T>(withForeignTable table: T, and columnConvertibleList: ColumnConvertible...) where T : RawRepresentable, T.RawValue == String {
+        self.init(withForeignTable: table.rawValue, and: columnConvertibleList)
+    }
+
     public enum Action: Describable {
         case setNull
         case setDefault

--- a/swift/source/abstract/JoinClause.swift
+++ b/swift/source/abstract/JoinClause.swift
@@ -41,8 +41,21 @@ public final class JoinClause: Describable {
         }
     }
 
+    public convenience init<T>(with subqueryConvertible: T)
+       where T : RawRepresentable, T.RawValue == String {
+        self.init(with: subqueryConvertible.rawValue)
+    }
+
     public init(with subqueryConvertible: TableOrSubqueryConvertible) {
         description = subqueryConvertible.asTableOrSubquery().description
+    }
+
+    @discardableResult
+    private func join<T>(_ subqueryConvertible: T,
+                      with type: JoinClauseType? = nil,
+                      isNatural: Bool = false) -> JoinClause
+        where T : RawRepresentable, T.RawValue == String {
+        return join(subqueryConvertible.rawValue, with: type, isNatural: isNatural)
     }
 
     @discardableResult
@@ -60,9 +73,23 @@ public final class JoinClause: Describable {
     }
 
     @discardableResult
+    public func join<T>(_ subqueryConvertible: T,
+                     with type: JoinClauseType? = nil) -> JoinClause
+        where T : RawRepresentable, T.RawValue == String {
+        return self.join(subqueryConvertible.rawValue, with: type, isNatural: false)
+    }
+
+    @discardableResult
     public func join(_ subqueryConvertible: TableOrSubqueryConvertible,
                      with type: JoinClauseType? = nil) -> JoinClause {
         return self.join(subqueryConvertible, with: type, isNatural: false)
+    }
+
+    @discardableResult
+    public func natureJoin<T>(_ subqueryConvertible: T,
+                           with type: JoinClauseType? = nil) -> JoinClause
+        where T : RawRepresentable, T.RawValue == String {
+        return self.join(subqueryConvertible.rawValue, with: type, isNatural: true)
     }
 
     @discardableResult

--- a/swift/source/abstract/StatementAlterTable.swift
+++ b/swift/source/abstract/StatementAlterTable.swift
@@ -35,9 +35,21 @@ public final class StatementAlterTable: Statement {
     }
 
     @discardableResult
+    public func alter<T>(table: T) -> StatementAlterTable
+        where T : RawRepresentable, T.RawValue == String {
+        return self.alter(table: table.rawValue)
+    }
+
+    @discardableResult
     public func rename(to newTable: String) -> StatementAlterTable {
         description.append(" RENAME TO \(newTable)")
         return self
+    }
+
+    @discardableResult
+    public func rename<T>(to newTable: T) -> StatementAlterTable
+        where T : RawRepresentable, T.RawValue == String {
+        return self.rename(to: newTable.rawValue)
     }
 
     @discardableResult

--- a/swift/source/abstract/StatementCreateIndex.swift
+++ b/swift/source/abstract/StatementCreateIndex.swift
@@ -49,6 +49,13 @@ public final class StatementCreateIndex: Statement {
     }
 
     @discardableResult
+    public func on<T>(table: T,
+                      indexesBy columnIndexConvertibleList: ColumnIndexConvertible...) -> StatementCreateIndex
+                       where T : RawRepresentable, T.RawValue == String {
+        return on(table: table.rawValue, indexesBy: columnIndexConvertibleList)
+    }
+
+    @discardableResult
     public func on(table: String,
                    indexesBy columnIndexConvertibleList: [ColumnIndexConvertible]) -> StatementCreateIndex {
         description.append(" ON \(table)(\(columnIndexConvertibleList.joined()))")

--- a/swift/source/abstract/StatementCreateTable.swift
+++ b/swift/source/abstract/StatementCreateTable.swift
@@ -28,6 +28,13 @@ public final class StatementCreateTable: Statement {
     public init() {}
 
     @discardableResult
+    public func create<T>(table: T, ifNotExists: Bool = true,
+                          as statementSelect: StatementSelect) -> StatementCreateTable
+        where T : RawRepresentable, T.RawValue == String {
+            return self.create(table: table.rawValue, ifNotExists: ifNotExists, as: statementSelect)
+    }
+
+    @discardableResult
     public func create(table: String, ifNotExists: Bool = true,
                        as statementSelect: StatementSelect) -> StatementCreateTable {
         description.append("CREATE TABLE ")
@@ -44,6 +51,15 @@ public final class StatementCreateTable: Statement {
                        with columnDefs: ColumnDef...,
                        and tableConstraints: [TableConstraint]? = nil) -> StatementCreateTable {
         return self.create(table: table, ifNotExists: ifNotExists, with: columnDefs, and: tableConstraints)
+    }
+
+    @discardableResult
+    public func create<T>(table: T,
+                       ifNotExists: Bool = true,
+                       with columnDefs: ColumnDef...,
+        and tableConstraints: [TableConstraint]? = nil) -> StatementCreateTable
+        where T : RawRepresentable, T.RawValue == String {
+        return self.create(table: table.rawValue, ifNotExists: ifNotExists, with: columnDefs, and: tableConstraints)
     }
 
     @discardableResult

--- a/swift/source/abstract/StatementCreateVirtualTable.swift
+++ b/swift/source/abstract/StatementCreateVirtualTable.swift
@@ -28,6 +28,12 @@ public final class StatementCreateVirtualTable: Statement {
     public init() {}
 
     @discardableResult
+    public func create<T>(virtualTable table: T, ifNotExists: Bool = true) -> StatementCreateVirtualTable
+        where T : RawRepresentable, T.RawValue == String {
+            return self.create(virtualTable: table.rawValue, ifNotExists: ifNotExists)
+    }
+
+    @discardableResult
     public func create(virtualTable table: String, ifNotExists: Bool = true) -> StatementCreateVirtualTable {
         description.append("CREATE VIRTUAL TABLE ")
         if ifNotExists {

--- a/swift/source/abstract/StatementDelete.swift
+++ b/swift/source/abstract/StatementDelete.swift
@@ -28,6 +28,12 @@ public final class StatementDelete: Statement {
     public init() {}
 
     @discardableResult
+    public func delete<T>(fromTable table: T) -> StatementDelete
+        where T : RawRepresentable, T.RawValue == String {
+            return self.delete(fromTable: table.rawValue)
+    }
+
+    @discardableResult
     public func delete(fromTable table: String) -> StatementDelete {
         description.append("DELETE FROM \(table)")
         return self

--- a/swift/source/abstract/StatementDropTable.swift
+++ b/swift/source/abstract/StatementDropTable.swift
@@ -27,6 +27,11 @@ public final class StatementDropTable: Statement {
 
     public init() {}
 
+    public func drop<T>(table: T, ifExists: Bool = true) -> StatementDropTable
+        where T : RawRepresentable, T.RawValue == String {
+            return self.drop(table: table.rawValue)
+    }
+
     public func drop(table: String, ifExists: Bool = true) -> StatementDropTable {
         description.append("DROP TABLE ")
         if ifExists {

--- a/swift/source/abstract/StatementInsert.swift
+++ b/swift/source/abstract/StatementInsert.swift
@@ -35,6 +35,14 @@ public final class StatementInsert: Statement {
     }
 
     @discardableResult
+    public func insert<T>(intoTable table: T,
+                       with columnConvertibleList: ColumnConvertible...,
+        onConflict conflict: Conflict? = nil) -> StatementInsert
+        where T : RawRepresentable, T.RawValue == String {
+        return insert(intoTable: table.rawValue, with: columnConvertibleList, onConflict: conflict)
+    }
+
+    @discardableResult
     public func insert(intoTable table: String,
                        with columnConvertibleList: [ColumnConvertible]? = nil,
                        onConflict conflict: Conflict? = nil) -> StatementInsert {
@@ -47,6 +55,14 @@ public final class StatementInsert: Statement {
             description.append("(\(columnConvertibleList!.joined()))")
         }
         return self
+    }
+
+    @discardableResult
+    public func insert<T>(intoTable table: T,
+                          with columnConvertibleList: [ColumnConvertible]? = nil,
+                          onConflict conflict: Conflict? = nil) -> StatementInsert
+        where T : RawRepresentable, T.RawValue == String {
+            return insert(intoTable: table.rawValue, with: columnConvertibleList, onConflict: conflict)
     }
 
     @discardableResult

--- a/swift/source/abstract/StatementSelect.swift
+++ b/swift/source/abstract/StatementSelect.swift
@@ -50,9 +50,21 @@ public final class StatementSelect: Statement {
     }
 
     @discardableResult
+    public func from<T>(_ tableOrSubqueryConvertibleList: T...) -> StatementSelect
+        where T : RawRepresentable, T.RawValue == String {
+            return from(tableOrSubqueryConvertibleList.flatMap{ Optional($0.rawValue) })
+    }
+
+    @discardableResult
     public func from(_ tableOrSubqueryConvertibleList: [TableOrSubqueryConvertible]) -> StatementSelect {
         description.append(" FROM \(tableOrSubqueryConvertibleList.joined())")
         return self
+    }
+
+    @discardableResult
+    public func from<T>(_ tableOrSubqueryConvertibleList: [T]) -> StatementSelect
+        where T : RawRepresentable, T.RawValue == String {
+        return from(tableOrSubqueryConvertibleList.flatMap{ Optional($0.rawValue) })
     }
 
     @discardableResult

--- a/swift/source/abstract/StatementUpdate.swift
+++ b/swift/source/abstract/StatementUpdate.swift
@@ -28,6 +28,12 @@ public final class StatementUpdate: Statement {
     public init() {}
 
     @discardableResult
+    public func update<T>(table: T, onConflict conflict: Conflict? = nil) -> StatementUpdate
+        where T : RawRepresentable, T.RawValue == String {
+        return update(table: table.rawValue, onConflict: conflict)
+    }
+
+    @discardableResult
     public func update(table: String, onConflict conflict: Conflict? = nil) -> StatementUpdate {
         description.append("UPDATE ")
         if conflict != nil {

--- a/swift/source/abstract/Subquery.swift
+++ b/swift/source/abstract/Subquery.swift
@@ -30,6 +30,11 @@ public final class Subquery: Describable {
         description = "(\(statementSelect.description))"
     }
 
+    public convenience init<T>(withTable table: T)
+        where T : RawRepresentable, T.RawValue == String {
+        self.init(withTable: table.rawValue)
+    }
+
     public init(withTable table: String) {
         description = table
     }

--- a/swift/source/core/base/Core.swift
+++ b/swift/source/core/base/Core.swift
@@ -62,7 +62,7 @@ public class Core: CoreRepresentable {
         fatalError("It should not be called. If you think it's a bug, please report an issue to us.")
     }
 
-    /// Prepare a specific sql.  
+    /// Prepare a specific sql.
     /// Note that you can use this interface to prepare a SQL that is not contained in the WCDB interface layer
     ///
     /// - Parameter statement: WINQ statement
@@ -70,6 +70,11 @@ public class Core: CoreRepresentable {
     /// - Throws: `Error`
     public func prepare(_ statement: Statement) throws -> CoreStatement {
         return CoreStatement(with: self, and: try prepare(statement))
+    }
+
+    public func isTableExists<T>(_ table: T) throws -> Bool
+        where T : RawRepresentable, T.RawValue == String {
+        return try isTableExists(table.rawValue)
     }
 
     public func isTableExists(_ table: String) throws -> Bool {
@@ -105,7 +110,7 @@ public class Core: CoreRepresentable {
 
     /// Run a transaction in closure
     ///
-    ///     try database.run(transaction: { () throws -> Void in 
+    ///     try database.run(transaction: { () throws -> Void in
     ///         try database.insert(objects: objects, intoTable: table)
     ///     })
     ///
@@ -124,7 +129,7 @@ public class Core: CoreRepresentable {
 
     /// Run a controllable transaction in closure
     ///
-    ///     try database.run(controllableTransaction: { () throws -> Bool in 
+    ///     try database.run(controllableTransaction: { () throws -> Bool in
     ///         try database.insert(objects: objects, intoTable: table)
     ///         return true // return true to commit transaction and return false to rollback transaction.
     ///     })

--- a/swift/source/core/base/Database.swift
+++ b/swift/source/core/base/Database.swift
@@ -26,10 +26,10 @@ import UIKit
 /// Thread-safe Database object
 public final class Database: Core {
 
-    /// Init a database from path.  
+    /// Init a database from path.
     /// Note that all database objects with same path share the same core.
-    /// So you can create multiple database objects. WCDB will manage them automatically.  
-    /// Note that WCDB will not generate a sqlite handle until the first operation, 
+    /// So you can create multiple database objects. WCDB will manage them automatically.
+    /// Note that WCDB will not generate a sqlite handle until the first operation,
     /// which is also called as lazy initialization.
     ///
     /// - Parameter path: Path to your database
@@ -37,10 +37,10 @@ public final class Database: Core {
         self.init(withFileURL: URL(fileURLWithPath: path))
     }
 
-    /// Init a database from file url.  
-    /// Note that all database objects with same path share the same core. 
-    /// So you can create multiple database objects. WCDB will manage them automatically.  
-    /// Note that WCDB will not generate a sqlite handle until the first operation, 
+    /// Init a database from file url.
+    /// Note that all database objects with same path share the same core.
+    /// So you can create multiple database objects. WCDB will manage them automatically.
+    /// Note that WCDB will not generate a sqlite handle until the first operation,
     /// which is also called as lazy initialization.
     ///
     /// - Parameter url: File url to your database
@@ -62,16 +62,16 @@ public final class Database: Core {
                         }
                     })
             })
-        #endif //WCDB_IOS     
+        #endif //WCDB_IOS
         super.init(with: HandlePool.getPool(withPath: url.standardizedFileURL.path,
                                             defaultConfigs: Database.defaultConfigs))
     }
 
-    /// Init a database from existing tag.  
-    /// Note that all database objects with same path share the same core. 
-    /// So you can create multiple database objects. WCDB will manage them automatically.  
-    /// Note that WCDB will not generate a sqlite handle until the first operation, 
-    /// which is also called as lazy initialization.  
+    /// Init a database from existing tag.
+    /// Note that all database objects with same path share the same core.
+    /// So you can create multiple database objects. WCDB will manage them automatically.
+    /// Note that WCDB will not generate a sqlite handle until the first operation,
+    /// which is also called as lazy initialization.
     ///
     /// - Parameter tag: An existing tag.
     /// - Throws: `Error` while tag is not exists
@@ -83,10 +83,10 @@ public final class Database: Core {
         super.init(with: try HandlePool.getExistingPool(withPath: path))
     }
 
-    /// The tag of the database. Default to nil.  
-    /// You should set it on a database and can get it from all kind of Core objects, 
-    /// including `Database`, `Table`, `Transaction`, `Select`, `RowSelect`, `MultiSelect`, `Insert`, `Delete`, 
-    /// `Update` and so on.   
+    /// The tag of the database. Default to nil.
+    /// You should set it on a database and can get it from all kind of Core objects,
+    /// including `Database`, `Table`, `Transaction`, `Select`, `RowSelect`, `MultiSelect`, `Insert`, `Delete`,
+    /// `Update` and so on.
     /// Note that core objects with same path share this tag, even they are not the same object.
     ///
     ///     let database1 = Database(withPath: path)
@@ -113,9 +113,9 @@ public final class Database: Core {
         return try handlePool.flowOut()
     }
 
-    /// Since WCDB is using lazy initialization, 
-    /// `init(withPath:)`, `init(withFileURL:)` never failed even the database can't open. 
-    /// So you can call this to check whether the database can be opened.  
+    /// Since WCDB is using lazy initialization,
+    /// `init(withPath:)`, `init(withFileURL:)` never failed even the database can't open.
+    /// So you can call this to check whether the database can be opened.
     /// Return false if an error occurs during sqlite handle initialization.
     public var canOpen: Bool {
         return !handlePool.isDrained || ((try? handlePool.fillOne()) != nil)
@@ -133,26 +133,26 @@ public final class Database: Core {
 
     public typealias OnClosed = HandlePool.OnDrained
 
-    /// Close the database.  
-    ///     Since Multi-threaded operation is supported in WCDB, 
-    ///     other operations in different thread can open the closed database. 
-    ///     So this method can make sure database is closed in the `onClosed` block. 
+    /// Close the database.
+    ///     Since Multi-threaded operation is supported in WCDB,
+    ///     other operations in different thread can open the closed database.
+    ///     So this method can make sure database is closed in the `onClosed` block.
     ///     All other operations will be blocked until this method returns.
     ///
-    /// A close operation consists of 4 steps:  
-    ///     1. `blockade`, which blocks all other operations.  
-    ///     2. `close`, which waits until all sqlite handles return and closes them.  
-    ///     3. `onClosed`, which trigger the callback.  
-    ///     4. `unblokade`, which unblocks all other opreations.  
+    /// A close operation consists of 4 steps:
+    ///     1. `blockade`, which blocks all other operations.
+    ///     2. `close`, which waits until all sqlite handles return and closes them.
+    ///     3. `onClosed`, which trigger the callback.
+    ///     4. `unblokade`, which unblocks all other opreations.
     ///
-    /// You can simply call `close:` to do all steps above or call these separately.  
-    /// Since this method will wait until all sqlite handles return, it may lead to deadlock in some bad practice. 
-    ///     The key to avoid deadlock is to make sure all WCDB objects in current thread is dealloced. In detail:  
-    ///     1. You should not keep WCDB objects, including `Insert`, `Delete`, `Update`, `Select`, `RowSelect`, 
-    ///        `MultiSelect`, `CoreStatement`, `Transaction`. These objects should not be kept.  
-    ///        You should get them, use them, then release them right away.  
-    ///     2. WCDB objects may not be out of its' scope.  
-    ///     The best practice is to call `close:` in sub-thread and display a loading animation in main thread.  
+    /// You can simply call `close:` to do all steps above or call these separately.
+    /// Since this method will wait until all sqlite handles return, it may lead to deadlock in some bad practice.
+    ///     The key to avoid deadlock is to make sure all WCDB objects in current thread is dealloced. In detail:
+    ///     1. You should not keep WCDB objects, including `Insert`, `Delete`, `Update`, `Select`, `RowSelect`,
+    ///        `MultiSelect`, `CoreStatement`, `Transaction`. These objects should not be kept.
+    ///        You should get them, use them, then release them right away.
+    ///     2. WCDB objects may not be out of its' scope.
+    ///     The best practice is to call `close:` in sub-thread and display a loading animation in main thread.
     ///
     ///     //close directly
     ///     database.close(onClosed: { () throws -> Void in
@@ -186,16 +186,16 @@ public final class Database: Core {
         handlePool.unblockade()
     }
 
-    /// Purge all unused memory of this database.  
-    /// WCDB will cache and reuse some sqlite handles to improve performance.   
+    /// Purge all unused memory of this database.
+    /// WCDB will cache and reuse some sqlite handles to improve performance.
     /// The max count of free sqlite handles is same
-    /// as the number of concurrent threads supported by the hardware implementation.  
+    /// as the number of concurrent threads supported by the hardware implementation.
     /// You can call it to save some memory.
     public func purge() {
         handlePool.purgeFreeHandles()
     }
 
-    /// Purge all unused memory of all databases.  
+    /// Purge all unused memory of all databases.
     /// Note that WCDB will call this interface automatically while it receives memory warning on iOS.
     public static func purge() {
         HandlePool.purgeFreeHandlesInAllPools()
@@ -206,8 +206,8 @@ public final class Database: Core {
         return try prepare(statement, in: recyclableHandle)
     }
 
-    /// Exec a specific sql.  
-    /// Note that you can use this interface to execute a SQL that is not contained in the WCDB interface layer. 
+    /// Exec a specific sql.
+    /// Note that you can use this interface to execute a SQL that is not contained in the WCDB interface layer.
     ///
     /// - Parameter statement: WINQ statement
     /// - Throws: `Error`
@@ -215,8 +215,8 @@ public final class Database: Core {
         try exec(statement, in: flowOut())
     }
 
-    /// Separate interface of `run(transaction:)`  
-    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.  
+    /// Separate interface of `run(transaction:)`
+    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.
     /// To do a cross-thread transaction, use `getTransaction`.
     /// - Throws: `Error`
     public override func begin(_ mode: StatementTransaction.Mode = .immediate) throws {
@@ -228,8 +228,8 @@ public final class Database: Core {
         Database.threadedHandles.value[path] = recyableHandlePool
     }
 
-    /// Separate interface of `run(transaction:)`  
-    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread. 
+    /// Separate interface of `run(transaction:)`
+    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.
     /// To do a cross-thread transaction, use `getTransaction`.
     /// - Throws: `Error`
     public override func commit() throws {
@@ -239,7 +239,7 @@ public final class Database: Core {
     }
 
     /// Separate interface of run(transaction:)
-    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.  
+    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.
     /// To do a cross-thread transaction, use `getTransaction`.
     /// - Throws: `Error`
     public override func rollback() throws {
@@ -248,11 +248,11 @@ public final class Database: Core {
         try recyableHandlePool.raw.handle.exec(CommonStatement.rollbackTransaction)
     }
 
-    /// Run a embedded transaction in closure  
-    /// The embedded transaction means that it will run a transaction if it's not in other transaction, 
+    /// Run a embedded transaction in closure
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
-    ///     try database.run(embeddedTransaction: { () throws -> Void in 
+    ///     try database.run(embeddedTransaction: { () throws -> Void in
     ///         try database.insert(objects: objects, intoTable: table)
     ///     })
     ///
@@ -269,11 +269,11 @@ public final class Database: Core {
 //Config
 extension Database {
 
-    /// Set cipher key for a database.   
-    /// For an encrypted database, you must call it before all other operation.  
-    /// The cipher page size defaults to 4096 in WCDB, but it defaults to 1024 in other databases. 
-    /// So for an existing database created by other database framework, you should set it to 1024. 
-    /// Otherwise, you'd better to use cipher page size with 4096 
+    /// Set cipher key for a database.
+    /// For an encrypted database, you must call it before all other operation.
+    /// The cipher page size defaults to 4096 in WCDB, but it defaults to 1024 in other databases.
+    /// So for an existing database created by other database framework, you should set it to 1024.
+    /// Otherwise, you'd better to use cipher page size with 4096
     /// or simply call setCipherKey: interface to get better performance.
     ///
     /// - Parameters:
@@ -297,15 +297,15 @@ extension Database {
     static private var performanceTracer = Atomic<PerformanceTracer?>()
     static private var sqlTracer = Atomic<SQLTracer?>()
 
-    /// You can register a tracer to monitor the performance of all SQLs.  
-    /// It returns  
-    /// 1. The collection of SQLs and the executions count of each SQL.  
-    /// 2. Time consuming in nanoseconds.  
-    /// 3. Tag of database.  
+    /// You can register a tracer to monitor the performance of all SQLs.
+    /// It returns
+    /// 1. The collection of SQLs and the executions count of each SQL.
+    /// 2. Time consuming in nanoseconds.
+    /// 3. Tag of database.
     ///
-    /// Note that:  
-    /// 1. You should register trace before all db operations.   
-    /// 2. Global tracer will be recovered by db tracer.  
+    /// Note that:
+    /// 1. You should register trace before all db operations.
+    /// 2. Global tracer will be recovered by db tracer.
     ///
     ///     Database.globalTrace(ofPerformance: { (tag, sqls, cost) in
     ///         if let wrappedTag = tag {
@@ -329,8 +329,8 @@ extension Database {
         performanceTracer.assign(nil)
     }
 
-    /// You can register a tracer to monitor the execution of all SQLs.  
-    /// It returns a prepared or executed SQL.  
+    /// You can register a tracer to monitor the execution of all SQLs.
+    /// It returns a prepared or executed SQL.
     /// Note that you should register trace before all db operations.
     ///
     ///     Database.globalTrace(ofSQL: { (sql) in
@@ -495,7 +495,7 @@ extension Database {
 
     /// Set config for this database.
     ///
-    /// Since WCDB is a multi-handle database, an executing handle will not apply this config immediately.  
+    /// Since WCDB is a multi-handle database, an executing handle will not apply this config immediately.
     /// Instead, all handles will run this config before its next operation.
     ///
     ///     database.setConfig(named: "demo", with: { (handle: Handle) throws in
@@ -519,8 +519,8 @@ extension Database {
         handlePool.setConfig(named: name, with: callback)
     }
 
-    /// Set Synchronous for this database. It will disable checkpoint opti to avoid performance degradation.  
-    /// Synchronous can improve the stability of the database and reduce database damage, 
+    /// Set Synchronous for this database. It will disable checkpoint opti to avoid performance degradation.
+    /// Synchronous can improve the stability of the database and reduce database damage,
     /// but there will be performance degradation.
     ///
     /// - Parameter isFull: enable or disable full synchronous
@@ -595,6 +595,20 @@ extension Database {
         }
         return Table<Root>(withDatabase: self, named: name)
     }
+
+    /// Get a wrapper from an existing table.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the table.
+    ///   - type: A class conform to TableCodable protocol.
+    /// - Returns: Nil for a non-existent table.
+    /// - Throws: `Error`
+    public func getTable<Root, T>(
+        named name: T,
+        of type: Root.Type = Root.self) throws -> Table<Root>?
+        where Root : TableCodable, T : RawRepresentable, T.RawValue == String {
+            return try getTable(named: name.rawValue, of: type)
+    }
 }
 
 //File
@@ -618,7 +632,7 @@ extension Database {
         })
     }
 
-    /// Remove all database-related files.  
+    /// Remove all database-related files.
     /// You should call it on a closed database. Otherwise you will get a warning.
     ///
     /// - Throws: `Error`
@@ -639,7 +653,7 @@ extension Database {
         try moveFiles(toDirectory: directory, withExtraFiles: extraFiles)
     }
 
-    /// Move all database-related files and some extra files to directory safely.  
+    /// Move all database-related files and some extra files to directory safely.
     /// You should call it on a closed database. Otherwise you will get a warning and you may get a corrupted database.
     ///
     /// - Parameters:
@@ -670,7 +684,7 @@ extension Database {
         try? File.remove(files: paths)
     }
 
-    /// Get the space used by the database files.  
+    /// Get the space used by the database files.
     /// You should call it on a closed database. Otherwise you will get a warning.
     ///
     /// - Returns: The sum of files size in bytes.
@@ -685,8 +699,8 @@ extension Database {
 
 //Repair
 extension Database {
-    /// Backup metadata to recover.  
-    /// Since metadata will be changed while a table or an index is created or dropped, 
+    /// Backup metadata to recover.
+    /// Since metadata will be changed while a table or an index is created or dropped,
     /// you should call this periodically.
     ///
     /// - Parameter key: The cipher key for backup. Nil for non-encrypted.
@@ -696,12 +710,12 @@ extension Database {
         try handle.raw.handle.backup(withKey: key)
     }
 
-    /// Recover data from a corruped db. You'd better to recover a closed database.  
+    /// Recover data from a corruped db. You'd better to recover a closed database.
     ///
     /// - Parameters:
     ///   - source: The path to the corrupted database
-    ///   - pageSize: Page size of the corrupted database. It's default to 4096 on iOS. 
-    ///               Page size never change unless you can call "PRAGMA page_size=NewPageSize" to set it. 
+    ///   - pageSize: Page size of the corrupted database. It's default to 4096 on iOS.
+    ///               Page size never change unless you can call "PRAGMA page_size=NewPageSize" to set it.
     ///               Also, you can call "PRAGMA page_size" to check the current value while database is not corrupted.
     ///   - databaseKey: The cipher key for corrupeted database
     ///   - backupKey: The cipher key for backup

--- a/swift/source/core/base/Transaction.swift
+++ b/swift/source/core/base/Transaction.swift
@@ -47,8 +47,8 @@ public final class Transaction: Core {
         return try prepare(statement, in: recyclableHandle)
     }
 
-    /// Exec a specific sql.  
-    /// Note that you can use this interface to execute a SQL that is not contained in the WCDB interface layer. 
+    /// Exec a specific sql.
+    /// Note that you can use this interface to execute a SQL that is not contained in the WCDB interface layer.
     ///
     /// - Parameter statement: WINQ statement
     /// - Throws: `Error`
@@ -57,7 +57,7 @@ public final class Transaction: Core {
         try exec(statement, in: recyclableHandle)
     }
 
-    /// Prepare a specific sql.  
+    /// Prepare a specific sql.
     /// Note that you can use this interface to prepare a SQL that is not contained in the WCDB interface layer
     ///
     /// - Parameter statement: WINQ statement
@@ -73,6 +73,16 @@ public final class Transaction: Core {
     /// - Parameter table: The name of the table to be checked.
     /// - Returns: True if table exists. False if table does not exist.
     /// - Throws: `Error`
+    public override func isTableExists<T>(_ table: T) throws -> Bool
+        where T : RawRepresentable, T.RawValue == String {
+        return try isTableExists(table.rawValue)
+    }
+
+    /// Check whether table exists
+    ///
+    /// - Parameter table: The name of the table to be checked.
+    /// - Returns: True if table exists. False if table does not exist.
+    /// - Throws: `Error`
     public override func isTableExists(_ table: String) throws -> Bool {
         mutex.lock(); defer { mutex.unlock() }
         return try super.isTableExists(table)
@@ -80,7 +90,7 @@ public final class Transaction: Core {
 
     /// Run a transaction in closure
     ///
-    ///     try transaction.run(transaction: { () throws -> Void in 
+    ///     try transaction.run(transaction: { () throws -> Void in
     ///         try transaction.insert(objects: objects, intoTable: table)
     ///     })
     ///
@@ -93,7 +103,7 @@ public final class Transaction: Core {
 
     /// Run a controllable transaction in closure
     ///
-    ///     try transaction.run(controllableTransaction: { () throws -> Bool in 
+    ///     try transaction.run(controllableTransaction: { () throws -> Bool in
     ///         try transaction.insert(objects: objects, intoTable: table)
     ///         return true // return true to commit transaction and return false to rollback transaction.
     ///     })
@@ -105,8 +115,8 @@ public final class Transaction: Core {
         try super.run(controllableTransaction: controllableTransaction)
     }
 
-    /// Separate interface of `run(transaction:)`  
-    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.  
+    /// Separate interface of `run(transaction:)`
+    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.
     /// - Throws: `Error`
     public override func begin(_ mode: StatementTransaction.Mode = .immediate) throws {
         mutex.lock(); defer { mutex.unlock() }
@@ -117,8 +127,8 @@ public final class Transaction: Core {
         isInTransaction = true
     }
 
-    /// Separate interface of `run(transaction:)`  
-    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread. 
+    /// Separate interface of `run(transaction:)`
+    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.
     /// - Throws: `Error`
     public override func commit() throws {
         mutex.lock(); defer { mutex.unlock() }
@@ -127,7 +137,7 @@ public final class Transaction: Core {
     }
 
     /// Separate interface of run(transaction:)
-    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.  
+    /// You should call `begin`, `commit`, `rollback` and all other operations in same thread.
     /// - Throws: `Error`
     public override func rollback() throws {
         mutex.lock(); defer { mutex.unlock() }
@@ -135,11 +145,11 @@ public final class Transaction: Core {
         try handle.exec(CommonStatement.rollbackTransaction)
     }
 
-    /// Run a embedded transaction in closure  
-    /// The embedded transaction means that it will run a transaction if it's not in other transaction, 
+    /// Run a embedded transaction in closure
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
-    ///     try transaction.run(embeddedTransaction: { () throws -> Void in 
+    ///     try transaction.run(embeddedTransaction: { () throws -> Void in
     ///         try transaction.insert(objects: objects, intoTable: table)
     ///     })
     ///
@@ -153,7 +163,7 @@ public final class Transaction: Core {
         return try run(transaction: embeddedTransaction)
     }
 
-    /// The number of changed rows in the most recent call.  
+    /// The number of changed rows in the most recent call.
     /// It should be called after executing successfully
     public var changes: Int {
         mutex.lock(); defer { mutex.unlock() }

--- a/swift/source/core/binding/Property.swift
+++ b/swift/source/core/binding/Property.swift
@@ -28,6 +28,13 @@ public protocol PropertyConvertible: ColumnConvertible, PropertyRedirectable {
     func `in`(table: String) -> Property
 }
 
+extension PropertyConvertible {
+    public func `in`<T>(table: T) -> Property
+        where T : RawRepresentable, T.RawValue == String {
+            return self.in(table: table.rawValue)
+    }
+}
+
 public typealias PropertyOperable = PropertyConvertible & ExpressionOperable
 
 public final class Property: Describable {

--- a/swift/source/core/binding/TableBinding.swift
+++ b/swift/source/core/binding/TableBinding.swift
@@ -121,6 +121,11 @@ public final class TableBinding<CodingTableKeyType: CodingTableKey> {
         return columnDef
     }
 
+    public func generateCreateVirtualTableStatement<T>(named table: T) -> StatementCreateVirtualTable
+        where T : RawRepresentable, T.RawValue == String {
+            return generateCreateVirtualTableStatement(named: table.rawValue)
+    }
+
     public func generateCreateVirtualTableStatement(named table: String) -> StatementCreateVirtualTable {
         assert(virtualTableBinding != nil, "Virtual table binding is not defined")
         let columnModuleArguments = allColumnDef.map { ModuleArgument(with: $0) }
@@ -135,11 +140,21 @@ public final class TableBinding<CodingTableKeyType: CodingTableKey> {
                    arguments: arguments)
     }
 
+    public func generateCreateTableStatement<T>(named table: T) -> StatementCreateTable
+        where T : RawRepresentable, T.RawValue == String {
+        return generateCreateTableStatement(named: table.rawValue)
+    }
+    
     public func generateCreateTableStatement(named table: String) -> StatementCreateTable {
         let tableConstraints = tableConstraintBindings?.map { $0.value.generateConstraint(withName: $0.key) }
         return StatementCreateTable().create(table: table,
                                              with: allColumnDef,
                                              and: tableConstraints)
+    }
+
+    public func generateCreateIndexStatements<T>(onTable table: T) -> [StatementCreateIndex]?
+        where T : RawRepresentable, T.RawValue == String {
+            return generateCreateIndexStatements(onTable: table.rawValue)
     }
 
     public func generateCreateIndexStatements(onTable table: String) -> [StatementCreateIndex]? {

--- a/swift/source/core/interface/ChainCall.swift
+++ b/swift/source/core/interface/ChainCall.swift
@@ -32,6 +32,16 @@ public protocol InsertChainCallInterface: class {
     /// - Throws: `Error`
     func prepareInsert<Root: TableEncodable>(of cls: Root.Type, intoTable table: String) throws -> Insert
 
+    /// Prepare chain call for inserting of `TableEncodable` object
+    ///
+    /// - Parameters:
+    ///   - cls: Type of table codable object
+    ///   - table: Table name
+    /// - Returns: `Insert`
+    /// - Throws: `Error`
+    func prepareInsert<Root, T>(of cls: Root.Type, intoTable table: T) throws -> Insert
+    where Root : TableEncodable, T : RawRepresentable, T.RawValue == String
+
     /// Prepare chain call for inserting or replacing of `TableEncodable` object
     ///
     /// - Parameters:
@@ -41,14 +51,33 @@ public protocol InsertChainCallInterface: class {
     /// - Throws: `Error`
     func prepareInsertOrReplace<Root: TableEncodable>(of cls: Root.Type, intoTable table: String) throws -> Insert
 
+    /// Prepare chain call for inserting or replacing of `TableEncodable` object
+    ///
+    /// - Parameters:
+    ///   - cls: Type of table codable object
+    ///   - table: Table name
+    /// - Returns: `Insert`
+    /// - Throws: `Error`
+    func prepareInsertOrReplace<Root, T>(of cls: Root.Type, intoTable table: T) throws -> Insert
+    where Root : TableEncodable, T : RawRepresentable, T.RawValue == String
+
     /// Prepare chain call for inserting on specific properties
     ///
     /// - Parameters:
-    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list 
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
     ///   - table: Table name
     /// - Returns: `Insert`
     /// - Throws: `Error`
     func prepareInsert(on propertyConvertibleList: PropertyConvertible..., intoTable table: String) throws -> Insert
+
+    /// Prepare chain call for inserting on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Returns: `Insert`
+    /// - Throws: `Error`
+    func prepareInsert<T>(on propertyConvertibleList: PropertyConvertible..., intoTable table: T) throws -> Insert where T : RawRepresentable, T.RawValue == String
 
     /// Prepare chain call for inserting or replacing on specific properties
     ///
@@ -60,6 +89,17 @@ public protocol InsertChainCallInterface: class {
     func prepareInsertOrReplace(on propertyConvertibleList: PropertyConvertible...,
                                 intoTable table: String) throws -> Insert
 
+    /// Prepare chain call for inserting or replacing on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Returns: `Insert`
+    /// - Throws: `Error`
+    func prepareInsertOrReplace<T>(on propertyConvertibleList: PropertyConvertible...,
+                                   intoTable table: T) throws -> Insert
+                                   where T : RawRepresentable, T.RawValue == String
+
     /// Prepare chain call for inserting on specific properties
     ///
     /// - Parameters:
@@ -70,6 +110,17 @@ public protocol InsertChainCallInterface: class {
     func prepareInsert(on propertyConvertibleList: [PropertyConvertible],
                        intoTable table: String) throws -> Insert
 
+    /// Prepare chain call for inserting on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Returns: `Insert`
+    /// - Throws: `Error`
+    func prepareInsert<T>(on propertyConvertibleList: [PropertyConvertible],
+                          intoTable table: T) throws -> Insert
+                          where T : RawRepresentable, T.RawValue == String
+
     /// Prepare chain call for inserting or replacing on specific properties
     ///
     /// - Parameters:
@@ -79,11 +130,34 @@ public protocol InsertChainCallInterface: class {
     /// - Throws: `Error`
     func prepareInsertOrReplace(on propertyConvertibleList: [PropertyConvertible],
                                 intoTable table: String) throws -> Insert
+
+    /// Prepare chain call for inserting or replacing on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Returns: `Insert`
+    /// - Throws: `Error`
+    func prepareInsertOrReplace<T>(on propertyConvertibleList: [PropertyConvertible],
+                                   intoTable table: T) throws -> Insert
+                                   where T : RawRepresentable, T.RawValue == String
 }
 
 extension InsertChainCallInterface where Self: Core {
     public func prepareInsert<Root: TableEncodable>(of cls: Root.Type, intoTable table: String) throws -> Insert {
         return try Insert(with: self, named: table, on: cls.Properties.all, isReplace: false)
+    }
+
+    public func prepareInsert<Root, T>(of cls: Root.Type, intoTable table: T) throws -> Insert
+        where Root : TableEncodable, T : RawRepresentable, T.RawValue == String {
+        return try prepareInsert(of: cls, intoTable: table.rawValue)
+    }
+
+    public func prepareInsertOrReplace<Root, T>(
+        of cls: Root.Type,
+        intoTable table: T) throws -> Insert
+        where Root : TableEncodable, T : RawRepresentable, T.RawValue == String {
+        return try prepareInsertOrReplace(of: cls, intoTable: table.rawValue)
     }
 
     public func prepareInsertOrReplace<Root: TableEncodable>(
@@ -97,14 +171,38 @@ extension InsertChainCallInterface where Self: Core {
         return try prepareInsert(on: propertyConvertibleList, intoTable: table)
     }
 
+    public func prepareInsert<T>(on propertyConvertibleList: PropertyConvertible...,
+        intoTable table: T) throws -> Insert
+        where T : RawRepresentable, T.RawValue == String {
+            return try prepareInsert(on: propertyConvertibleList, intoTable: table.rawValue)
+    }
+
     public func prepareInsertOrReplace(on propertyConvertibleList: PropertyConvertible...,
                                        intoTable table: String) throws -> Insert {
         return try prepareInsertOrReplace(on: propertyConvertibleList, intoTable: table)
     }
 
+    public func prepareInsertOrReplace<T>(on propertyConvertibleList: PropertyConvertible...,
+        intoTable table: T) throws -> Insert
+        where T : RawRepresentable, T.RawValue == String {
+        return try prepareInsertOrReplace(on: propertyConvertibleList, intoTable: table.rawValue)
+    }
+    
+    public func prepareInsert<T>(on propertyConvertibleList: [PropertyConvertible],
+                                 intoTable table: T) throws -> Insert
+                                 where T : RawRepresentable, T.RawValue == String {
+        return try prepareInsert(on: propertyConvertibleList, intoTable: table.rawValue)
+    }
+
     public func prepareInsert(on propertyConvertibleList: [PropertyConvertible],
                               intoTable table: String) throws -> Insert {
         return try Insert(with: self, named: table, on: propertyConvertibleList, isReplace: false)
+    }
+
+    public func prepareInsertOrReplace<T>(on propertyConvertibleList: [PropertyConvertible],
+                                       intoTable table: T) throws -> Insert
+                                       where T : RawRepresentable, T.RawValue == String {
+        return try prepareInsertOrReplace(on: propertyConvertibleList, intoTable: table.rawValue)
     }
 
     public func prepareInsertOrReplace(on propertyConvertibleList: [PropertyConvertible],
@@ -122,9 +220,21 @@ public protocol DeleteChainCallInterface: class {
     /// - Returns: `Delete`
     /// - Throws: `Error`
     func prepareDelete(fromTable table: String) throws -> Delete
+
+    /// Prepare chain call for deleting on specific properties
+    ///
+    /// - Parameter table: Table name
+    /// - Returns: `Delete`
+    /// - Throws: `Error`
+    func prepareDelete<T>(fromTable table: T) throws -> Delete where T : RawRepresentable, T.RawValue == String
 }
 
 extension DeleteChainCallInterface where Self: Core {
+    public func prepareDelete<T>(fromTable table: T) throws -> Delete
+        where T : RawRepresentable, T.RawValue == String {
+            return try prepareDelete(fromTable: table.rawValue)
+    }
+
     public func prepareDelete(fromTable table: String) throws -> Delete {
         return try Delete(with: self, andTableName: table)
     }
@@ -149,7 +259,25 @@ public protocol UpdateChainCallInterface: class {
     ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
     /// - Returns: `Update`
     /// - Throws: `Error`
+    func prepareUpdate<T>(table: T, on propertyConvertibleList: PropertyConvertible...) throws -> Update where T : RawRepresentable, T.RawValue == String
+
+    /// Prepare chain call for updating on specific properties
+    ///
+    /// - Parameters:
+    ///   - table: Table name
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    /// - Returns: `Update`
+    /// - Throws: `Error`
     func prepareUpdate(table: String, on propertyConvertibleList: [PropertyConvertible]) throws -> Update
+
+    /// Prepare chain call for updating on specific properties
+    ///
+    /// - Parameters:
+    ///   - table: Table name
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    /// - Returns: `Update`
+    /// - Throws: `Error`
+    func prepareUpdate<T>(table: T, on propertyConvertibleList: [PropertyConvertible]) throws -> Update where T : RawRepresentable, T.RawValue == String
 }
 
 extension UpdateChainCallInterface where Self: Core {
@@ -157,8 +285,16 @@ extension UpdateChainCallInterface where Self: Core {
         return try prepareUpdate(table: table, on: propertyConvertibleList)
     }
 
+    public func prepareUpdate<T>(table: T, on propertyConvertibleList: PropertyConvertible...) throws -> Update where T : RawRepresentable, T.RawValue == String {
+        return try prepareUpdate(table: table.rawValue, on: propertyConvertibleList)
+    }
+
     public func prepareUpdate(table: String, on propertyConvertibleList: [PropertyConvertible]) throws -> Update {
         return try Update(with: self, on: propertyConvertibleList, andTable: table)
+    }
+    
+    public func prepareUpdate<T>(table: T, on propertyConvertibleList: [PropertyConvertible]) throws -> Update where T : RawRepresentable, T.RawValue == String {
+        return try prepareUpdate(table: table.rawValue, on: propertyConvertibleList)
     }
 }
 
@@ -185,9 +321,35 @@ public protocol RowSelectChainCallInterface: class {
     ///   - isDistinct: Is distinct or not
     /// - Returns: `RowSelect`
     /// - Throws: `Error`
+    func prepareRowSelect<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+                             fromTables tables: [T],
+                             isDistinct: Bool) throws -> RowSelect
+                             where T : RawRepresentable, T.RawValue == String
+
+    /// Prepare chain call for row-selecting on specific column results
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: `ColumnResult` list
+    ///   - tables: Table name list
+    ///   - isDistinct: Is distinct or not
+    /// - Returns: `RowSelect`
+    /// - Throws: `Error`
     func prepareRowSelect(on columnResultConvertibleList: [ColumnResultConvertible],
                           fromTables tables: [String],
                           isDistinct: Bool) throws -> RowSelect
+
+    /// Prepare chain call for row-selecting on specific column results
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: `ColumnResult` list
+    ///   - tables: Table name list
+    ///   - isDistinct: Is distinct or not
+    /// - Returns: `RowSelect`
+    /// - Throws: `Error`
+    func prepareRowSelect<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                             fromTables tables: [T],
+                             isDistinct: Bool) throws -> RowSelect
+                             where T : RawRepresentable, T.RawValue == String
 
     /// Prepare chain call for row-selecting on specific column results
     ///
@@ -209,9 +371,35 @@ public protocol RowSelectChainCallInterface: class {
     ///   - isDistinct: Is distinct or not
     /// - Returns: `RowSelect`
     /// - Throws: `Error`
+    func prepareRowSelect<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+                             fromTable table: T,
+                             isDistinct: Bool) throws -> RowSelect
+                             where T : RawRepresentable, T.RawValue == String
+
+    /// Prepare chain call for row-selecting on specific column results
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: `ColumnResult` list
+    ///   - tables: Table name
+    ///   - isDistinct: Is distinct or not
+    /// - Returns: `RowSelect`
+    /// - Throws: `Error`
     func prepareRowSelect(on columnResultConvertibleList: [ColumnResultConvertible],
                           fromTable table: String,
                           isDistinct: Bool) throws -> RowSelect
+
+    /// Prepare chain call for row-selecting on specific column results
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: `ColumnResult` list
+    ///   - tables: Table name
+    ///   - isDistinct: Is distinct or not
+    /// - Returns: `RowSelect`
+    /// - Throws: `Error`
+    func prepareRowSelect<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                             fromTable table: T,
+                             isDistinct: Bool) throws -> RowSelect
+                             where T : RawRepresentable, T.RawValue == String
 }
 
 extension RowSelectChainCallInterface where Self: Core {
@@ -222,6 +410,23 @@ extension RowSelectChainCallInterface where Self: Core {
             [Column.any] : columnResultConvertibleList,
                                     fromTables: tables,
                                     isDistinct: isDistinct)
+    }
+
+    public func prepareRowSelect<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+        fromTables tables: [T],
+        isDistinct: Bool = false) throws -> RowSelect
+        where T : RawRepresentable, T.RawValue == String {
+        return try prepareRowSelect(on: columnResultConvertibleList.isEmpty ?
+            [Column.any] : columnResultConvertibleList,
+                                    fromTables: tables.flatMap{ Optional($0.rawValue) },
+                                    isDistinct: isDistinct)
+    }
+
+    public func prepareRowSelect<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                                 fromTables tables: [T],
+                                 isDistinct: Bool = false) throws -> RowSelect
+                                 where T : RawRepresentable, T.RawValue == String {
+                                    return try prepareRowSelect(on: columnResultConvertibleList, fromTables: tables.flatMap{ Optional($0.rawValue) }, isDistinct: isDistinct)
     }
 
     public func prepareRowSelect(on columnResultConvertibleList: [ColumnResultConvertible],
@@ -237,6 +442,23 @@ extension RowSelectChainCallInterface where Self: Core {
             [Column.any] : columnResultConvertibleList,
                                     fromTable: table,
                                     isDistinct: isDistinct)
+    }
+
+    public func prepareRowSelect<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+        fromTable table: T,
+        isDistinct: Bool = false) throws -> RowSelect
+        where T : RawRepresentable, T.RawValue == String {
+        return try prepareRowSelect(on: columnResultConvertibleList.isEmpty ?
+            [Column.any] : columnResultConvertibleList,
+                                    fromTable: table.rawValue,
+                                    isDistinct: isDistinct)
+    }
+
+    public func prepareRowSelect<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                                    fromTable table: T,
+                                    isDistinct: Bool = false) throws -> RowSelect
+                                    where T : RawRepresentable, T.RawValue == String {
+        return try prepareRowSelect(on: columnResultConvertibleList, fromTable: table.rawValue, isDistinct: isDistinct)
     }
 
     public func prepareRowSelect(on columnResultConvertibleList: [ColumnResultConvertible],
@@ -264,6 +486,19 @@ public protocol SelectChainCallInterface: class {
                                              fromTable table: String,
                                              isDistinct: Bool) throws -> Select
 
+    /// Prepare chain call for selecting of `TableDecodable` object
+    ///
+    /// - Parameters:
+    ///   - cls: Type of table decodable object
+    ///   - table: Table name
+    ///   - isDistinct: Is distinct or not
+    /// - Returns: `Select`
+    /// - Throws: `Error`
+    func prepareSelect<Root, T>(of cls: Root.Type,
+                                fromTable table: T,
+                                isDistinct: Bool) throws -> Select
+                                where Root : TableDecodable, T : RawRepresentable, T.RawValue == String
+
     /// Prepare chain call for selecting on specific properties
     ///
     /// - Parameters:
@@ -284,12 +519,45 @@ public protocol SelectChainCallInterface: class {
     ///   - isDistinct: Is distinct or not
     /// - Returns: `Select`
     /// - Throws: `Error`
+    func prepareSelect<T>(on propertyConvertibleList: PropertyConvertible...,
+                          fromTable table: T,
+                          isDistinct: Bool) throws -> Select
+                          where T : RawRepresentable, T.RawValue == String
+
+    /// Prepare chain call for selecting on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    ///   - isDistinct: Is distinct or not
+    /// - Returns: `Select`
+    /// - Throws: `Error`
     func prepareSelect(on propertyConvertibleList: [PropertyConvertible],
                        fromTable table: String,
                        isDistinct: Bool) throws -> Select
+    
+    /// Prepare chain call for selecting on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    ///   - isDistinct: Is distinct or not
+    /// - Returns: `Select`
+    /// - Throws: `Error`
+    func prepareSelect<T>(on propertyConvertibleList: [PropertyConvertible],
+                          fromTable table: T,
+                          isDistinct: Bool) throws -> Select
+                          where T : RawRepresentable, T.RawValue == String
 }
 
 extension SelectChainCallInterface where Self: Core {
+    public func prepareSelect<Root, T>(of cls: Root.Type,
+                                       fromTable table: T,
+                                       isDistinct: Bool = false) throws -> Select
+        where Root : TableDecodable, T : RawRepresentable, T.RawValue == String {
+        return try prepareSelect(of: cls, fromTable: table.rawValue)
+    }
+
     public func prepareSelect<Root: TableDecodable>(of cls: Root.Type,
                                                     fromTable table: String,
                                                     isDistinct: Bool = false) throws -> Select {
@@ -304,10 +572,26 @@ extension SelectChainCallInterface where Self: Core {
                                  isDistinct: isDistinct)
     }
 
+    public func prepareSelect<T>(on propertyConvertibleList: PropertyConvertible...,
+        fromTable table: T,
+        isDistinct: Bool = false) throws -> Select
+        where T : RawRepresentable, T.RawValue == String {
+        return try prepareSelect(on: propertyConvertibleList,
+                                 fromTable: table.rawValue,
+                                 isDistinct: isDistinct)
+    }
+
     public func prepareSelect(on propertyConvertibleList: [PropertyConvertible],
                               fromTable table: String,
                               isDistinct: Bool = false) throws -> Select {
         return try Select(with: self, on: propertyConvertibleList, table: table, isDistinct: isDistinct)
+    }
+    
+    public func prepareSelect<T>(on propertyConvertibleList: [PropertyConvertible],
+                                 fromTable table: T,
+                                 isDistinct: Bool = false) throws -> Select
+                                where T : RawRepresentable, T.RawValue == String {
+            return try prepareSelect(on: propertyConvertibleList, fromTable: table.rawValue, isDistinct: isDistinct)
     }
 }
 
@@ -331,8 +615,30 @@ public protocol MultiSelectChainCallInterface: class {
     ///   - tables: Table name list
     /// - Returns: `MultiSelect`
     /// - Throws: `Error`
+    func prepareMultiSelect<T>(on propertyConvertibleList: PropertyConvertible...,
+                               fromTables tables: [T]) throws -> MultiSelect
+                               where T : RawRepresentable, T.RawValue == String
+
+    /// Prepare chain call for multi-selecting on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - tables: Table name list
+    /// - Returns: `MultiSelect`
+    /// - Throws: `Error`
     func prepareMultiSelect(on propertyConvertibleList: [PropertyConvertible],
                             fromTables tables: [String]) throws -> MultiSelect
+    
+    /// Prepare chain call for multi-selecting on specific properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - tables: Table name list
+    /// - Returns: `MultiSelect`
+    /// - Throws: `Error`
+    func prepareMultiSelect<T>(on propertyConvertibleList: [PropertyConvertible],
+                               fromTables tables: [T]) throws -> MultiSelect
+                               where T : RawRepresentable, T.RawValue == String
 }
 
 extension MultiSelectChainCallInterface where Self: Core {
@@ -341,8 +647,20 @@ extension MultiSelectChainCallInterface where Self: Core {
         return try prepareMultiSelect(on: propertyConvertibleList, fromTables: tables)
     }
 
+    public func prepareMultiSelect<T>(on propertyConvertibleList: PropertyConvertible...,
+        fromTables tables: [T]) throws -> MultiSelect
+        where T : RawRepresentable, T.RawValue == String {
+            return try prepareMultiSelect(on: propertyConvertibleList, fromTables: tables.flatMap{ Optional($0.rawValue) })
+    }
+
     public func prepareMultiSelect(on propertyConvertibleList: [PropertyConvertible],
                                    fromTables tables: [String]) throws -> MultiSelect {
         return try MultiSelect(with: self, on: propertyConvertibleList, tables: tables)
+    }
+    
+    public func prepareMultiSelect<T>(on propertyConvertibleList: [PropertyConvertible],
+                                      fromTables tables: [T]) throws -> MultiSelect
+                                      where T : RawRepresentable, T.RawValue == String {
+        return try prepareMultiSelect(on: propertyConvertibleList, fromTables: tables.flatMap{ Optional($0.rawValue) })
     }
 }

--- a/swift/source/core/interface/Interface.swift
+++ b/swift/source/core/interface/Interface.swift
@@ -25,7 +25,7 @@ public protocol InsertInterface: class {
 
     /// Execute inserting with `TableEncodable` object on specific(or all) properties
     ///
-    /// Note that it will run embedded transaction while objects.count>1.  
+    /// Note that it will run embedded transaction while objects.count>1.
     /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
@@ -36,12 +36,45 @@ public protocol InsertInterface: class {
     /// - Throws: `Error`
     func insert<Object: TableEncodable>(
         objects: Object...,
+        on propertyConvertibleList: [PropertyConvertible]?,
+        intoTable table: String) throws
+    
+    /// Execute inserting with `TableEncodable` object on specific(or all) properties
+    ///
+    /// Note that it will run embedded transaction while objects.count>1.
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
+    /// otherwise it will be executed within the existing transaction.
+    ///
+    /// - Parameters:
+    ///   - objects: Table encodable object
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Throws: `Error`
+    func insert<Object, T>(
+        objects: Object...,
+        on propertyConvertibleList: [PropertyConvertible]?,
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String
+
+    /// Execute inserting with `TableEncodable` object on specific(or all) properties
+    ///
+    /// Note that it will run embedded transaction while objects.count>1.
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
+    /// otherwise it will be executed within the existing transaction.
+    ///
+    /// - Parameters:
+    ///   - objects: Table encodable object
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Throws: `Error`
+    func insert<Object: TableEncodable>(
+        objects: [Object],
         on propertyConvertibleList: [PropertyConvertible]?,
         intoTable table: String) throws
 
     /// Execute inserting with `TableEncodable` object on specific(or all) properties
     ///
-    /// Note that it will run embedded transaction while objects.count>1.  
+    /// Note that it will run embedded transaction while objects.count>1.
     /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
@@ -50,15 +83,16 @@ public protocol InsertInterface: class {
     ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
     ///   - table: Table name
     /// - Throws: `Error`
-    func insert<Object: TableEncodable>(
+    func insert<Object, T>(
         objects: [Object],
         on propertyConvertibleList: [PropertyConvertible]?,
-        intoTable table: String) throws
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String
 
-    /// Execute inserting or replacing with `TableEncodable` object on specific(or all) properties.  
+    /// Execute inserting or replacing with `TableEncodable` object on specific(or all) properties.
     /// It will replace the original row while they have same primary key or row id.
     ///
-    /// Note that it will run embedded transaction while objects.count>1.  
+    /// Note that it will run embedded transaction while objects.count>1.
     /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
@@ -72,10 +106,28 @@ public protocol InsertInterface: class {
         on propertyConvertibleList: [PropertyConvertible]?,
         intoTable table: String) throws
 
-    /// Execute inserting or replacing with `TableEncodable` object on specific(or all) properties.  
+    /// Execute inserting or replacing with `TableEncodable` object on specific(or all) properties.
     /// It will replace the original row while they have same primary key or row id.
     ///
-    /// Note that it will run embedded transaction while objects.count>1.  
+    /// Note that it will run embedded transaction while objects.count>1.
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
+    /// otherwise it will be executed within the existing transaction.
+    ///
+    /// - Parameters:
+    ///   - objects: Table encodable object
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Throws: `Error`
+    func insertOrReplace<Object, T>(
+        objects: Object...,
+        on propertyConvertibleList: [PropertyConvertible]?,
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String
+
+    /// Execute inserting or replacing with `TableEncodable` object on specific(or all) properties.
+    /// It will replace the original row while they have same primary key or row id.
+    ///
+    /// Note that it will run embedded transaction while objects.count>1.
     /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
@@ -88,9 +140,36 @@ public protocol InsertInterface: class {
         objects: [Object],
         on propertyConvertibleList: [PropertyConvertible]?,
         intoTable table: String) throws
+
+    /// Execute inserting or replacing with `TableEncodable` object on specific(or all) properties.
+    /// It will replace the original row while they have same primary key or row id.
+    ///
+    /// Note that it will run embedded transaction while objects.count>1.
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
+    /// otherwise it will be executed within the existing transaction.
+    ///
+    /// - Parameters:
+    ///   - objects: Table encodable object
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    /// - Throws: `Error`
+    func insertOrReplace<Object, T>(
+        objects: [Object],
+        on propertyConvertibleList: [PropertyConvertible]?,
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String
+    
 }
 
 extension InsertInterface where Self: Core {
+    public func insert<Object, T>(
+        objects: [Object],
+        on propertyConvertibleList: [PropertyConvertible]? = nil,
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String {
+            return try insert(objects: objects, on: propertyConvertibleList, intoTable: table.rawValue)
+    }
+
     public func insert<Object: TableEncodable>(
         objects: [Object],
         on propertyConvertibleList: [PropertyConvertible]? = nil,
@@ -106,6 +185,14 @@ extension InsertInterface where Self: Core {
         let insert = try Insert(with: self, named: table, on: propertyConvertibleList, isReplace: true)
         return try insert.execute(with: objects)
     }
+    
+    public func insertOrReplace<Object, T>(
+        objects: [Object],
+        on propertyConvertibleList: [PropertyConvertible]? = nil,
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String {
+            return try insertOrReplace(objects: objects, on: propertyConvertibleList, intoTable: table.rawValue)
+    }
 
     public func insert<Object: TableEncodable>(
         objects: Object...,
@@ -114,18 +201,34 @@ extension InsertInterface where Self: Core {
         return try insert(objects: objects, on: propertyConvertibleList, intoTable: table)
     }
 
+    public func insert<Object, T>(
+        objects: Object...,
+        on propertyConvertibleList: [PropertyConvertible]? = nil,
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String {
+            return try insert(objects: objects, on: propertyConvertibleList, intoTable: table.rawValue)
+    }
+
     public func insertOrReplace<Object: TableEncodable>(
         objects: Object...,
         on propertyConvertibleList: [PropertyConvertible]? = nil,
         intoTable table: String) throws {
         return try insertOrReplace(objects: objects, on: propertyConvertibleList, intoTable: table)
     }
+
+    public func insertOrReplace<Object, T>(
+        objects: Object...,
+        on propertyConvertibleList: [PropertyConvertible]? = nil,
+        intoTable table: T) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String {
+        return try insertOrReplace(objects: objects, on: propertyConvertibleList, intoTable: table.rawValue)
+    }
 }
 
 /// Convenient interface for updating
 public protocol UpdateInterface: class {
 
-    /// Execute updating with `TableEncodable` object on specific(or all) properties. 
+    /// Execute updating with `TableEncodable` object on specific(or all) properties.
     ///
     /// - Parameters:
     ///   - table: Table name
@@ -145,7 +248,28 @@ public protocol UpdateInterface: class {
         limit: Limit?,
         offset: Offset?) throws
 
-    /// Execute updating with `TableEncodable` object on specific(or all) properties. 
+    /// Execute updating with `TableEncodable` object on specific(or all) properties.
+    ///
+    /// - Parameters:
+    ///   - table: Table name
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - object: Table encodable object
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Throws: `Error`
+    func update<Object, T>(
+        table: T,
+        on propertyConvertibleList: PropertyConvertible...,
+        with object: Object,
+        where condition: Condition?,
+        orderBy orderList: [OrderBy]?,
+        limit: Limit?,
+        offset: Offset?) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String
+
+    /// Execute updating with `TableEncodable` object on specific(or all) properties.
     ///
     /// - Parameters:
     ///   - table: Table name
@@ -165,7 +289,28 @@ public protocol UpdateInterface: class {
         limit: Limit?,
         offset: Offset?) throws
 
-    /// Execute updating with row on specific(or all) properties. 
+    /// Execute updating with `TableEncodable` object on specific(or all) properties.
+    ///
+    /// - Parameters:
+    ///   - table: Table name
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - object: Table encodable object
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Throws: `Error`
+    func update<Object, T>(
+        table: T,
+        on propertyConvertibleList: [PropertyConvertible],
+        with object: Object,
+        where condition: Condition?,
+        orderBy orderList: [OrderBy]?,
+        limit: Limit?,
+        offset: Offset?) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String
+
+    /// Execute updating with row on specific(or all) properties.
     ///
     /// - Parameters:
     ///   - table: Table name
@@ -184,7 +329,27 @@ public protocol UpdateInterface: class {
                 limit: Limit?,
                 offset: Offset?) throws
 
-    /// Execute updating with row on specific(or all) properties. 
+    /// Execute updating with row on specific(or all) properties.
+    ///
+    /// - Parameters:
+    ///   - table: Table name
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - object: Table encodable object
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Throws: `Error`
+    func update<T>(table: T,
+                   on propertyConvertibleList: PropertyConvertible...,
+                   with row: [ColumnEncodableBase],
+                   where condition: Condition?,
+                   orderBy orderList: [OrderBy]?,
+                   limit: Limit?,
+                   offset: Offset?) throws
+                   where T : RawRepresentable, T.RawValue == String
+
+    /// Execute updating with row on specific(or all) properties.
     ///
     /// - Parameters:
     ///   - table: Table name
@@ -202,6 +367,26 @@ public protocol UpdateInterface: class {
                 orderBy orderList: [OrderBy]?,
                 limit: Limit?,
                 offset: Offset?) throws
+
+    /// Execute updating with row on specific(or all) properties.
+    ///
+    /// - Parameters:
+    ///   - table: Table name
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - object: Table encodable object
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Throws: `Error`
+    func update<T>(table: T,
+                on propertyConvertibleList: [PropertyConvertible],
+                with row: [ColumnEncodableBase],
+                where condition: Condition?,
+                orderBy orderList: [OrderBy]?,
+                limit: Limit?,
+                offset: Offset?) throws
+                where T : RawRepresentable, T.RawValue == String
 }
 
 extension UpdateInterface where Self: Core {
@@ -230,6 +415,18 @@ extension UpdateInterface where Self: Core {
         return try update.execute(with: object)
     }
 
+    public func update<Object, T>(
+        table: T,
+        on propertyConvertibleList: [PropertyConvertible],
+        with object: Object,
+        where condition: Condition? = nil,
+        orderBy orderList: [OrderBy]? = nil,
+        limit: Limit? = nil,
+        offset: Offset? = nil) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String {
+        return try update(table: table.rawValue, on: propertyConvertibleList, with: object, where: condition, orderBy: orderList, limit: limit, offset: offset)
+    }
+
     public func update<Object: TableEncodable>(
         table: String,
         on propertyConvertibleList: PropertyConvertible...,
@@ -239,6 +436,24 @@ extension UpdateInterface where Self: Core {
         limit: Limit? = nil,
         offset: Offset? = nil) throws {
         return try update(table: table,
+                          on: propertyConvertibleList,
+                          with: object,
+                          where: condition,
+                          orderBy: orderList,
+                          limit: limit,
+                          offset: offset)
+    }
+
+    public func update<Object, T>(
+        table: T,
+        on propertyConvertibleList: PropertyConvertible...,
+        with object: Object,
+        where condition: Condition? = nil,
+        orderBy orderList: [OrderBy]? = nil,
+        limit: Limit? = nil,
+        offset: Offset? = nil) throws
+        where Object : TableEncodable, T : RawRepresentable, T.RawValue == String {
+        return try update(table: table.rawValue,
                           on: propertyConvertibleList,
                           with: object,
                           where: condition,
@@ -263,6 +478,34 @@ extension UpdateInterface where Self: Core {
                           offset: offset)
     }
 
+    public func update<T>(table: T,
+                          on propertyConvertibleList: PropertyConvertible...,
+                          with row: [ColumnEncodableBase],
+                          where condition: Condition? = nil,
+                          orderBy orderList: [OrderBy]? = nil,
+                          limit: Limit? = nil,
+                          offset: Offset? = nil) throws
+                          where T : RawRepresentable, T.RawValue == String {
+        return try update(table: table.rawValue,
+                          on: propertyConvertibleList,
+                          with: row,
+                          where: condition,
+                          orderBy: orderList,
+                          limit: limit,
+                          offset: offset)
+    }
+
+    public func update<T>(table: T,
+                          on propertyConvertibleList: [PropertyConvertible],
+                          with row: [ColumnEncodableBase],
+                          where condition: Condition? = nil,
+                          orderBy orderList: [OrderBy]? = nil,
+                          limit: Limit? = nil,
+                          offset: Offset? = nil) throws
+                          where T : RawRepresentable, T.RawValue == String {
+            return try update(table: table.rawValue, on: propertyConvertibleList, with: row, where: condition, orderBy: orderList, limit: limit, offset: offset)
+        
+    }
     public func update(table: String,
                        on propertyConvertibleList: [PropertyConvertible],
                        with row: [ColumnEncodableBase],
@@ -291,7 +534,7 @@ extension UpdateInterface where Self: Core {
 /// Convenient interface for deleting
 public protocol DeleteInterface: class {
 
-    /// Execute deleting 
+    /// Execute deleting
     ///
     /// - Parameters:
     ///   - table: Table name
@@ -305,9 +548,34 @@ public protocol DeleteInterface: class {
                 orderBy orderList: [OrderBy]?,
                 limit: Limit?,
                 offset: Offset?) throws
+
+    /// Execute deleting
+    ///
+    /// - Parameters:
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Throws: `Error`
+    func delete<T>(fromTable table: T,
+                   where condition: Condition?,
+                   orderBy orderList: [OrderBy]?,
+                   limit: Limit?,
+                   offset: Offset?) throws
+                   where T : RawRepresentable, T.RawValue == String
 }
 
 extension DeleteInterface where Self: Core {
+    public func delete<T>(fromTable table: T,
+                          where condition: Condition? = nil,
+                          orderBy orderList: [OrderBy]? = nil,
+                          limit: Limit? = nil,
+                          offset: Offset? = nil) throws
+                          where T : RawRepresentable, T.RawValue == String {
+            return try delete(fromTable: table.rawValue, where: condition, orderBy: orderList, limit: limit, offset: offset)
+    }
+
     public func delete(fromTable table: String,
                        where condition: Condition? = nil,
                        orderBy orderList: [OrderBy]? = nil,
@@ -363,12 +631,50 @@ public protocol RowSelectInterface: class {
     ///   - offset: Expression convertible
     /// - Returns: `FundamentalRowXColumn`
     /// - Throws: `Error`
+    func getRows<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                    fromTable table: T,
+                    where condition: Condition?,
+                    orderBy orderList: [OrderBy]?,
+                    limit: Limit?,
+                    offset: Offset?) throws -> FundamentalRowXColumn
+                    where T : RawRepresentable, T.RawValue == String
+
+    /// Get rows by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: WINQ column result list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalRowXColumn`
+    /// - Throws: `Error`
     func getRows(on columnResultConvertibleList: ColumnResultConvertible...,
                  fromTable table: String,
                  where condition: Condition?,
                  orderBy orderList: [OrderBy]?,
                  limit: Limit?,
                  offset: Offset?) throws -> FundamentalRowXColumn
+
+    /// Get rows by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: WINQ column result list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalRowXColumn`
+    /// - Throws: `Error`
+    func getRows<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+                    fromTable table: T,
+                    where condition: Condition?,
+                    orderBy orderList: [OrderBy]?,
+                    limit: Limit?,
+                    offset: Offset?) throws -> FundamentalRowXColumn
+                    where T : RawRepresentable, T.RawValue == String
 
     /// Get row by specific selecting
     ///
@@ -396,11 +702,45 @@ public protocol RowSelectInterface: class {
     ///   - offset: Expression convertible
     /// - Returns: `FundamentalRow`
     /// - Throws: `Error`
+    func getRow<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+                   fromTable table: T,
+                   where condition: Condition?,
+                   orderBy orderList: [OrderBy]?,
+                   offset: Offset?) throws -> FundamentalRow
+                   where T : RawRepresentable, T.RawValue == String
+
+    /// Get row by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: WINQ column result list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalRow`
+    /// - Throws: `Error`
     func getRow(on columnResultConvertibleList: [ColumnResultConvertible],
                 fromTable table: String,
                 where condition: Condition?,
                 orderBy orderList: [OrderBy]?,
                 offset: Offset?) throws -> FundamentalRow
+
+    /// Get row by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertibleList: WINQ column result list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalRow`
+    /// - Throws: `Error`
+    func getRow<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                   fromTable table: T,
+                   where condition: Condition?,
+                   orderBy orderList: [OrderBy]?,
+                   offset: Offset?) throws -> FundamentalRow
+                   where T : RawRepresentable, T.RawValue == String
 
     /// Get column by specific selecting
     ///
@@ -420,6 +760,25 @@ public protocol RowSelectInterface: class {
                    limit: Limit?,
                    offset: Offset?) throws -> FundamentalColumn
 
+    /// Get column by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertible: WINQ column result
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalColumn`
+    /// - Throws: `Error`
+    func getColumn<T>(on result: ColumnResultConvertible,
+                      fromTable table: T,
+                      where condition: Condition?,
+                      orderBy orderList: [OrderBy]?,
+                      limit: Limit?,
+                      offset: Offset?) throws -> FundamentalColumn
+                      where T : RawRepresentable, T.RawValue == String
+
     /// Get distinct column by specific selecting
     ///
     /// - Parameters:
@@ -437,7 +796,25 @@ public protocol RowSelectInterface: class {
                            orderBy orderList: [OrderBy]?,
                            limit: Limit?,
                            offset: Offset?) throws -> FundamentalColumn
-
+    
+    /// Get distinct column by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertible: WINQ column result
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalColumn`
+    /// - Throws: `Error`
+    func getDistinctColumn<T>(on result: ColumnResultConvertible,
+                              fromTable table: T,
+                              where condition: Condition?,
+                              orderBy orderList: [OrderBy]?,
+                              limit: Limit?,
+                              offset: Offset?) throws -> FundamentalColumn
+                              where T : RawRepresentable, T.RawValue == String
     /// Get value by specific selecting
     ///
     /// - Parameters:
@@ -455,6 +832,24 @@ public protocol RowSelectInterface: class {
                   limit: Limit?,
                   offset: Offset?) throws -> FundamentalValue
 
+    /// Get value by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertible: WINQ column result
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalValue`
+    /// - Throws: `Error`
+    func getValue<T>(on result: ColumnResultConvertible,
+                     fromTable table: T,
+                     where condition: Condition?,
+                     orderBy orderList: [OrderBy]?,
+                     limit: Limit?,
+                     offset: Offset?) throws -> FundamentalValue
+                     where T : RawRepresentable, T.RawValue == String
+
     /// Get distinct value by specific selecting
     ///
     /// - Parameters:
@@ -471,9 +866,37 @@ public protocol RowSelectInterface: class {
                           orderBy orderList: [OrderBy]?,
                           limit: Limit?,
                           offset: Offset?) throws -> FundamentalValue
+
+    /// Get distinct value by specific selecting
+    ///
+    /// - Parameters:
+    ///   - columnResultConvertible: WINQ column result
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - offset: Expression convertible
+    /// - Returns: `FundamentalValue`
+    /// - Throws: `Error`
+    func getDistinctValue<T>(on result: ColumnResultConvertible,
+                             fromTable table: T,
+                             where condition: Condition?,
+                             orderBy orderList: [OrderBy]?,
+                             limit: Limit?,
+                             offset: Offset?) throws -> FundamentalValue
+                             where T : RawRepresentable, T.RawValue == String
 }
 
 extension RowSelectInterface where Self: Core {
+    public func getRows<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                           fromTable table: T,
+                           where condition: Condition? = nil,
+                           orderBy orderList: [OrderBy]? = nil,
+                           limit: Limit? = nil,
+                           offset: Offset? = nil) throws -> FundamentalRowXColumn
+                           where T : RawRepresentable, T.RawValue == String {
+        return try getRows(on: columnResultConvertibleList, fromTable: table.rawValue, where: condition, orderBy: orderList, limit: limit, offset: offset)
+    }
+
     public func getRows(on columnResultConvertibleList: [ColumnResultConvertible],
                         fromTable table: String,
                         where condition: Condition? = nil,
@@ -515,6 +938,22 @@ extension RowSelectInterface where Self: Core {
             offset: offset)
     }
 
+    public func getRows<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+                           fromTable table: T,
+                           where condition: Condition? = nil,
+                           orderBy orderList: [OrderBy]? = nil,
+                           limit: Limit? = nil,
+                           offset: Offset? = nil) throws -> FundamentalRowXColumn
+                           where T : RawRepresentable, T.RawValue == String {
+        return try getRows(
+            on: columnResultConvertibleList.isEmpty ? [Column.any] : columnResultConvertibleList,
+            fromTable: table.rawValue,
+            where: condition,
+            orderBy: orderList,
+            limit: limit,
+            offset: offset)
+    }
+
     public func getRow(on columnResultConvertibleList: ColumnResultConvertible...,
                        fromTable table: String,
                        where condition: Condition? = nil,
@@ -523,6 +962,20 @@ extension RowSelectInterface where Self: Core {
         return try getRow(
             on: columnResultConvertibleList.isEmpty ? [Column.any] : columnResultConvertibleList,
             fromTable: table,
+            where: condition,
+            orderBy: orderList,
+            offset: offset)
+    }
+
+    public func getRow<T>(on columnResultConvertibleList: ColumnResultConvertible...,
+                          fromTable table: T,
+                          where condition: Condition? = nil,
+                          orderBy orderList: [OrderBy]? = nil,
+                          offset: Offset? = nil) throws -> FundamentalRow
+                          where T : RawRepresentable, T.RawValue == String {
+        return try getRow(
+            on: columnResultConvertibleList.isEmpty ? [Column.any] : columnResultConvertibleList,
+            fromTable: table.rawValue,
             where: condition,
             orderBy: orderList,
             offset: offset)
@@ -539,6 +992,25 @@ extension RowSelectInterface where Self: Core {
                            orderBy: orderList,
                            limit: 1,
                            offset: offset).first ?? []
+    }
+
+    public func getRow<T>(on columnResultConvertibleList: [ColumnResultConvertible],
+                          fromTable table: T,
+                          where condition: Condition? = nil,
+                          orderBy orderList: [OrderBy]? = nil,
+                          offset: Offset? = nil) throws -> FundamentalRow
+                          where T : RawRepresentable, T.RawValue == String {
+        return try getRow(on: columnResultConvertibleList, fromTable: table.rawValue, where: condition, orderBy: orderList, offset: offset)
+    }
+
+    public func getColumn<T>(on result: ColumnResultConvertible,
+                             fromTable table: T,
+                             where condition: Condition? = nil,
+                             orderBy orderList: [OrderBy]? = nil,
+                             limit: Limit? = nil,
+                             offset: Offset? = nil) throws -> FundamentalColumn
+                             where T : RawRepresentable, T.RawValue == String {
+          return try getColumn(on: result, fromTable: table.rawValue, where: condition, orderBy: orderList, limit: limit, offset: offset)
     }
 
     public func getColumn(on result: ColumnResultConvertible,
@@ -564,6 +1036,16 @@ extension RowSelectInterface where Self: Core {
         return try rowSelect.allValues()
     }
 
+    public func getDistinctColumn<T>(on result: ColumnResultConvertible,
+                                     fromTable table: T,
+                                     where condition: Condition? = nil,
+                                     orderBy orderList: [OrderBy]? = nil,
+                                     limit: Limit? = nil,
+                                     offset: Offset? = nil) throws -> FundamentalColumn
+                                     where T : RawRepresentable, T.RawValue == String {
+        return try getDistinctColumn(on: result, fromTable: table.rawValue, where: condition, orderBy: orderList, limit: limit, offset: offset)
+    }
+
     public func getDistinctColumn(on result: ColumnResultConvertible,
                                   fromTable table: String,
                                   where condition: Condition? = nil,
@@ -587,6 +1069,16 @@ extension RowSelectInterface where Self: Core {
         return try rowSelect.allValues()
     }
 
+    public func getValue<T>(on result: ColumnResultConvertible,
+                            fromTable table: T,
+                            where condition: Condition? = nil,
+                            orderBy orderList: [OrderBy]? = nil,
+                            limit: Limit? = nil,
+                            offset: Offset? = nil) throws -> FundamentalValue
+        where T : RawRepresentable, T.RawValue == String {
+            return try getValue(on: result, fromTable: table.rawValue, where: condition, orderBy: orderList, limit: limit, offset: offset)
+    }
+
     public func getValue(on result: ColumnResultConvertible,
                          fromTable table: String,
                          where condition: Condition? = nil,
@@ -599,6 +1091,16 @@ extension RowSelectInterface where Self: Core {
                             orderBy: orderList,
                             limit: 1,
                             offset: offset).first?.first) ?? FundamentalValue(nil)
+    }
+
+    public func getDistinctValue<T>(on result: ColumnResultConvertible,
+                                    fromTable table: T,
+                                    where condition: Condition? = nil,
+                                    orderBy orderList: [OrderBy]? = nil,
+                                    limit: Limit? = nil,
+                                    offset: Offset? = nil) throws -> FundamentalValue
+        where T : RawRepresentable, T.RawValue == String {
+            return try getDistinctValue(on: result, fromTable: table.rawValue, where: condition, orderBy: orderList, limit: limit, offset: offset)
     }
 
     public func getDistinctValue(on result: ColumnResultConvertible,
@@ -645,6 +1147,26 @@ public protocol SelectInterface: class {
     ///   - offset: Expression convertible
     /// - Returns: Table decodable objects
     /// - Throws: `Error`
+    func getObjects<Object, T>(
+        on propertyConvertibleList: [PropertyConvertible],
+        fromTable table: T,
+        where condition: Condition?,
+        orderBy orderList: [OrderBy]?,
+        limit: Limit?,
+        offset: Offset?) throws -> [Object]
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String
+
+    /// Get objects on specific(or all) properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Returns: Table decodable objects
+    /// - Throws: `Error`
     func getObjects<Object: TableDecodable>(
         on propertyConvertibleList: PropertyConvertible...,
         fromTable table: String,
@@ -652,6 +1174,26 @@ public protocol SelectInterface: class {
         orderBy orderList: [OrderBy]?,
         limit: Limit?,
         offset: Offset?) throws -> [Object]
+
+    /// Get objects on specific(or all) properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - limit: Expression convertible
+    ///   - offset: Expression convertible
+    /// - Returns: Table decodable objects
+    /// - Throws: `Error`
+    func getObjects<Object, T>(
+        on propertyConvertibleList: PropertyConvertible...,
+        fromTable table: T,
+        where condition: Condition?,
+        orderBy orderList: [OrderBy]?,
+        limit: Limit?,
+        offset: Offset?) throws -> [Object]
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String
 
     /// Get object on specific(or all) properties
     ///
@@ -677,6 +1219,24 @@ public protocol SelectInterface: class {
     ///   - table: Table name
     ///   - condition: Expression convertible
     ///   - orderList: Order convertible list
+    ///   - offset: Expression convertible
+    /// - Returns: Table decodable objects
+    /// - Throws: `Error`
+    func getObject<Object, T>(
+        on propertyConvertibleList: [PropertyConvertible],
+        fromTable table: T,
+        where condition: Condition?,
+        orderBy orderList: [OrderBy]?,
+        offset: Offset?) throws -> Object?
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String
+
+    /// Get object on specific(or all) properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
     ///   - condition: Expression convertible
     /// - Returns: Table decodable objects
     /// - Throws: `Error`
@@ -686,9 +1246,38 @@ public protocol SelectInterface: class {
         where condition: Condition?,
         orderBy orderList: [OrderBy]?,
         offset: Offset?) throws -> Object?
+
+    /// Get object on specific(or all) properties
+    ///
+    /// - Parameters:
+    ///   - propertyConvertibleList: `Property` or `CodingTableKey` list
+    ///   - table: Table name
+    ///   - condition: Expression convertible
+    ///   - orderList: Order convertible list
+    ///   - condition: Expression convertible
+    /// - Returns: Table decodable objects
+    /// - Throws: `Error`
+    func getObject<Object, T>(
+        on propertyConvertibleList: PropertyConvertible...,
+        fromTable table: T,
+        where condition: Condition?,
+        orderBy orderList: [OrderBy]?,
+        offset: Offset?) throws -> Object?
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String
 }
 
 extension SelectInterface where Self: Core {
+    public func getObjects<Object, T>(
+        on propertyConvertibleList: [PropertyConvertible],
+        fromTable table: T,
+        where condition: Condition? = nil,
+        orderBy orderList: [OrderBy]? = nil,
+        limit: Limit? = nil,
+        offset: Offset? = nil) throws -> [Object]
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String {
+            return try getObjects(on: propertyConvertibleList, fromTable: table.rawValue, where: condition, orderBy: orderList, limit: limit, offset: offset)
+    }
+
     public func getObjects<Object: TableDecodable>(
         on propertyConvertibleList: [PropertyConvertible],
         fromTable table: String,
@@ -728,6 +1317,32 @@ extension SelectInterface where Self: Core {
                               offset: offset)
     }
 
+    public func getObjects<Object, T>(
+        on propertyConvertibleList: PropertyConvertible...,
+        fromTable table: T,
+        where condition: Condition? = nil,
+        orderBy orderList: [OrderBy]? = nil,
+        limit: Limit? = nil,
+        offset: Offset? = nil) throws -> [Object]
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String {
+        return try getObjects(on: propertyConvertibleList.isEmpty ? Object.Properties.all : propertyConvertibleList,
+                              fromTable: table.rawValue,
+                              where: condition,
+                              orderBy: orderList,
+                              limit: limit,
+                              offset: offset)
+    }
+
+    public func getObject<Object, T>(
+        on propertyConvertibleList: [PropertyConvertible],
+        fromTable table: T,
+        where condition: Condition? = nil,
+        orderBy orderList: [OrderBy]? = nil,
+        offset: Offset? = nil) throws -> Object?
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String {
+            return try getObject(on: propertyConvertibleList, fromTable: table.rawValue, where: condition, orderBy: orderList, offset: offset)
+    }
+
     public func getObject<Object: TableDecodable>(
         on propertyConvertibleList: [PropertyConvertible],
         fromTable table: String,
@@ -754,6 +1369,20 @@ extension SelectInterface where Self: Core {
                              orderBy: orderList,
                              offset: offset)
     }
+
+    public func getObject<Object, T>(
+        on propertyConvertibleList: PropertyConvertible...,
+        fromTable table: T,
+        where condition: Condition? = nil,
+        orderBy orderList: [OrderBy]? = nil,
+        offset: Offset? = nil) throws -> Object?
+        where Object : TableDecodable, T : RawRepresentable, T.RawValue == String {
+        return try getObject(on: propertyConvertibleList.isEmpty ? Object.Properties.all : propertyConvertibleList,
+                             fromTable: table.rawValue,
+                             where: condition,
+                             orderBy: orderList,
+                             offset: offset)
+    }
 }
 
 /// Convenient interface for table related operation
@@ -761,13 +1390,13 @@ public protocol TableInterface: class {
     /// Create table, related indexes and constraints with specific type
     ///
     /// Note that it will create defined indexes automatically.
-    /// The name of index is `"\(tableName)\(indexSubfixName)"` while `indexSubfixName` is defined by `IndexBinding`. 
+    /// The name of index is `"\(tableName)\(indexSubfixName)"` while `indexSubfixName` is defined by `IndexBinding`.
     /// BUT, it will not drop the undefined indexes. You should drop it manually.
     ///
     /// Note that it will add the newly defined column automatically.
     /// AND, it will skip the undefined column. It can be very developer-friendly while upgrading your database column.
     ///
-    /// Note that it will run embedded transaction  
+    /// Note that it will run embedded transaction
     /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
@@ -776,10 +1405,29 @@ public protocol TableInterface: class {
     ///   - rootType: Type of table encodable object
     /// - Throws: `Error`
     func create<Root: TableDecodable>(table name: String, of rootType: Root.Type) throws
+    
+    /// Create table, related indexes and constraints with specific type
+    ///
+    /// Note that it will create defined indexes automatically.
+    /// The name of index is `"\(tableName)\(indexSubfixName)"` while `indexSubfixName` is defined by `IndexBinding`.
+    /// BUT, it will not drop the undefined indexes. You should drop it manually.
+    ///
+    /// Note that it will add the newly defined column automatically.
+    /// AND, it will skip the undefined column. It can be very developer-friendly while upgrading your database column.
+    ///
+    /// Note that it will run embedded transaction
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
+    /// otherwise it will be executed within the existing transaction.
+    ///
+    /// - Parameters:
+    ///   - name: Table name.
+    ///   - rootType: Type of table encodable object
+    /// - Throws: `Error`
+    func create<Root, T>(table name: T, of rootType: Root.Type) throws where Root : TableDecodable, T : RawRepresentable, T.RawValue == String
 
     /// Create virtual table and constraints with specific type
     ///
-    /// Note that it will run embedded transaction  
+    /// Note that it will run embedded transaction
     /// The embedded transaction means that it will run a transaction if it's not in other transaction,
     /// otherwise it will be executed within the existing transaction.
     ///
@@ -789,6 +1437,18 @@ public protocol TableInterface: class {
     /// - Throws: `Error`
     func create<Root: TableDecodable>(virtualTable name: String, of rootType: Root.Type) throws
 
+    /// Create virtual table and constraints with specific type
+    ///
+    /// Note that it will run embedded transaction
+    /// The embedded transaction means that it will run a transaction if it's not in other transaction,
+    /// otherwise it will be executed within the existing transaction.
+    ///
+    /// - Parameters:
+    ///   - name: Table name.
+    ///   - rootType: Type of table encodable object
+    /// - Throws: `Error`
+    func create<Root, T>(virtualTable name: T, of rootType: Root.Type) throws where Root : TableDecodable, T : RawRepresentable, T.RawValue == String
+
     /// Create table manually
     ///
     /// - Parameters:
@@ -797,6 +1457,15 @@ public protocol TableInterface: class {
     ///   - constraintList: WINQ constraint list.
     /// - Throws: `Error`
     func create(table name: String, with columnDefList: [ColumnDef], and constraintList: [TableConstraint]?) throws
+    
+    /// Create table manually
+    ///
+    /// - Parameters:
+    ///   - name: Table name
+    ///   - columnDefList: WINQ column definition list
+    ///   - constraintList: WINQ constraint list.
+    /// - Throws: `Error`
+    func create<T>(table name: T, with columnDefList: [ColumnDef], and constraintList: [TableConstraint]?) throws where T : RawRepresentable, T.RawValue == String
 
     /// Create table manually
     ///
@@ -807,6 +1476,15 @@ public protocol TableInterface: class {
     /// - Throws: `Error`
     func create(table name: String, with columnDefList: ColumnDef..., and constraintList: [TableConstraint]?) throws
 
+    /// Create table manually
+    ///
+    /// - Parameters:
+    ///   - name: Table name
+    ///   - columnDefList: WINQ column definition list
+    ///   - constraintList: WINQ constraint list.
+    /// - Throws: `Error`
+    func create<T>(table name: T, with columnDefList: ColumnDef..., and constraintList: [TableConstraint]?) throws where T : RawRepresentable, T.RawValue == String
+
     /// Create new column
     ///
     /// - Parameters:
@@ -815,11 +1493,25 @@ public protocol TableInterface: class {
     /// - Throws: `Error`
     func addColumn(with columnDef: ColumnDef, forTable table: String) throws
 
+    /// Create new column
+    ///
+    /// - Parameters:
+    ///   - columnDef: WINQ column definition
+    ///   - table: Table name
+    /// - Throws: `Error`
+    func addColumn<T>(with columnDef: ColumnDef, forTable table: T) throws where T : RawRepresentable, T.RawValue == String
+
     /// Drop table
     ///
     /// - Parameter name: Table name
     /// - Throws: `Erro`
     func drop(table name: String) throws
+
+    /// Drop table
+    ///
+    /// - Parameter name: Table name
+    /// - Throws: `Erro`
+    func drop<T>(table name: T) throws where T : RawRepresentable, T.RawValue == String
 
     /// Create index manually
     ///
@@ -831,6 +1523,18 @@ public protocol TableInterface: class {
     func create(index name: String,
                 with columnIndexConvertibleList: [ColumnIndexConvertible],
                 forTable table: String) throws
+    
+    /// Create index manually
+    ///
+    /// - Parameters:
+    ///   - name: Index name
+    ///   - columnIndexConvertibleList: WINQ column index list
+    ///   - table: Table name
+    /// - Throws: `Error`
+    func create<T>(index name: String,
+                   with columnIndexConvertibleList: [ColumnIndexConvertible],
+                   forTable table: T) throws
+                   where T : RawRepresentable, T.RawValue == String
 
     /// Create index manually
     ///
@@ -843,6 +1547,18 @@ public protocol TableInterface: class {
                 with columnIndexConvertibleList: ColumnIndexConvertible...,
                 forTable table: String) throws
 
+    /// Create index manually
+    ///
+    /// - Parameters:
+    ///   - name: Index name
+    ///   - columnIndexConvertibleList: WINQ column index list
+    ///   - table: Table name
+    /// - Throws: `Error`
+    func create<T>(index name: String,
+                   with columnIndexConvertibleList: ColumnIndexConvertible...,
+                   forTable table: T) throws
+                   where T : RawRepresentable, T.RawValue == String
+
     /// Drop index
     ///
     /// - Parameter name: Index name
@@ -851,6 +1567,13 @@ public protocol TableInterface: class {
 }
 
 extension TableInterface where Self: Core {
+    public func create<Root, T>(
+        table name: T,
+        of rootType: Root.Type) throws
+        where Root : TableDecodable, T : RawRepresentable, T.RawValue == String {
+            return try create(table: name.rawValue, of: rootType)
+    }
+
     public func create<Root: TableDecodable>(
         table name: String,
         of rootType: Root.Type) throws {
@@ -887,6 +1610,11 @@ extension TableInterface where Self: Core {
         })
     }
 
+    public func create<Root, T>(virtualTable name: T, of rootType: Root.Type) throws
+        where Root : TableDecodable, T : RawRepresentable, T.RawValue == String {
+            return try create(virtualTable: name.rawValue, of: rootType)
+    }
+
     public func create<Root: TableDecodable>(virtualTable name: String, of rootType: Root.Type) throws {
         try run(transaction: {
             try exec(rootType.CodingKeys.objectRelationalMapping.generateCreateVirtualTableStatement(named: name))
@@ -899,18 +1627,49 @@ extension TableInterface where Self: Core {
         try create(table: name, with: columnDefList, and: constraintList)
     }
 
+    public func create<T>(table name: T,
+                       with columnDefList: ColumnDef...,
+        and constraintList: [TableConstraint]? = nil) throws
+        where T : RawRepresentable, T.RawValue == String {
+        try create(table: name.rawValue, with: columnDefList, and: constraintList)
+    }
+
+    public func create<T>(table name: T,
+                          with columnDefList: [ColumnDef],
+                          and constraintList: [TableConstraint]? = nil) throws
+                        where T : RawRepresentable, T.RawValue == String {
+            return try create(table: name.rawValue, with: columnDefList, and: constraintList)
+    }
+
     public func create(table name: String,
                        with columnDefList: [ColumnDef],
                        and constraintList: [TableConstraint]? = nil) throws {
         try exec(StatementCreateTable().create(table: name, with: columnDefList, and: constraintList))
     }
 
+    public func addColumn<T>(with columnDef: ColumnDef, forTable table: T) throws
+        where T : RawRepresentable, T.RawValue == String {
+        try addColumn(with: columnDef, forTable: table.rawValue)
+    }
+
     public func addColumn(with columnDef: ColumnDef, forTable table: String) throws {
         try exec(StatementAlterTable().alter(table: table).addColumn(with: columnDef))
     }
 
+    public func drop<T>(table name: T) throws
+        where T : RawRepresentable, T.RawValue == String {
+            try drop(table: name.rawValue)
+    }
+
     public func drop(table name: String) throws {
         try exec(StatementDropTable().drop(table: name))
+    }
+
+    public func create<T>(index name: String,
+                          with columnIndexConvertibleList: ColumnIndexConvertible...,
+                          forTable table: T) throws
+                          where T : RawRepresentable, T.RawValue == String {
+            try create(index: name, with: columnIndexConvertibleList, forTable: table.rawValue)
     }
 
     public func create(index name: String,
@@ -923,6 +1682,13 @@ extension TableInterface where Self: Core {
                        with columnIndexConvertibleList: [ColumnIndexConvertible],
                        forTable table: String) throws {
         try exec(StatementCreateIndex().create(index: name).on(table: table, indexesBy: columnIndexConvertibleList))
+    }
+
+    public func create<T>(index name: String,
+                          with columnIndexConvertibleList: [ColumnIndexConvertible],
+                          forTable table: T) throws
+                          where T : RawRepresentable, T.RawValue == String {
+        try create(index: name, with: columnIndexConvertibleList, forTable: table.rawValue)
     }
 
     public func drop(index name: String) throws {


### PR DESCRIPTION
## Motivation 
`String`s are evil. 

We can use `Enum` or any other `RawRepresentable` to represent `table` name

## UniTests
- [x] All Testcases passed
