### PR TITLE
WCTDatabase initialize only once

### DIFF
--- a/objc/source/interface/core/WCTDatabase.mm
+++ b/objc/source/interface/core/WCTDatabase.mm
@@ -29,41 +29,43 @@
 
 + (void)initialize
 {
-    [WCTTokenizer enroll];
+    if (self == [WCTDatabase self]) {
+        [WCTTokenizer enroll];
 #if TARGET_OS_IPHONE
-    WCDB::SQLiteGlobal::shared()->hookVFSDidFileCreated([](const char *path) {
-        if (!path) {
-            return;
-        }
-        NSError *nsError = nil;
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *nsPath = [NSString stringWithUTF8String:path];
-        NSDictionary *attributes = [fileManager attributesOfItemAtPath:nsPath error:&nsError];
-        if (attributes) {
-            NSString *fileProtection = [attributes objectForKey:NSFileProtectionKey];
-            if ([fileProtection isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication] || [fileProtection isEqualToString:NSFileProtectionNone]) {
+        WCDB::SQLiteGlobal::shared()->hookVFSDidFileCreated([](const char *path) {
+            if (!path) {
                 return;
             }
-            NSDictionary *fileProtectionAttribute = @{NSFileProtectionKey : NSFileProtectionCompleteUntilFirstUserAuthentication};
-            [fileManager setAttributes:fileProtectionAttribute
-                          ofItemAtPath:nsPath
-                                 error:&nsError];
-        }
-        if (nsError) {
-            WCDB::Error error;
-            error.setCode(WCDB::Error::Code::IOError, "Native");
-            if (nsError.description.length > 0) {
-                error.message = nsError.description.cppString;
-            } else {
-                error.message = WCDB::Error::CodeName(WCDB::Error::Code::IOError);
+            NSError *nsError = nil;
+            NSFileManager *fileManager = [NSFileManager defaultManager];
+            NSString *nsPath = [NSString stringWithUTF8String:path];
+            NSDictionary *attributes = [fileManager attributesOfItemAtPath:nsPath error:&nsError];
+            if (attributes) {
+                NSString *fileProtection = [attributes objectForKey:NSFileProtectionKey];
+                if ([fileProtection isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication] || [fileProtection isEqualToString:NSFileProtectionNone]) {
+                    return;
+                }
+                NSDictionary *fileProtectionAttribute = @{NSFileProtectionKey : NSFileProtectionCompleteUntilFirstUserAuthentication};
+                [fileManager setAttributes:fileProtectionAttribute
+                              ofItemAtPath:nsPath
+                                     error:&nsError];
             }
-            error.infos.set("Path", path);
-            error.infos.set("ExtCode", nsError.code);
-            WCDB::Reporter::shared()->report(error);
-            WCDB::ThreadedErrors::shared()->setThreadedError(std::move(error));
-        }
-    });
+            if (nsError) {
+                WCDB::Error error;
+                error.setCode(WCDB::Error::Code::IOError, "Native");
+                if (nsError.description.length > 0) {
+                    error.message = nsError.description.cppString;
+                } else {
+                    error.message = WCDB::Error::CodeName(WCDB::Error::Code::IOError);
+                }
+                error.infos.set("Path", path);
+                error.infos.set("ExtCode", nsError.code);
+                WCDB::Reporter::shared()->report(error);
+                WCDB::ThreadedErrors::shared()->setThreadedError(std::move(error));
+            }
+        });
 #endif //TARGET_OS_IPHONE
+    }
 }
 
 - (instancetype)initWithPath:(NSString *)path


### PR DESCRIPTION
We support subclass `WCTDatabase`, like `WCTMigrationDatabase`...
So let's do initialize only once.