### PR TITLE
fix valueType

### DIFF
--- a/objc/source/interface/core/WCTValue.mm
+++ b/objc/source/interface/core/WCTValue.mm
@@ -25,16 +25,16 @@
 
 - (WCTValueType)valueType
 {
-    if ([self isKindOfClass:NSString.class]) {
+    if ([self isKindOfClass:NSNull.class]) {
+        return WCTValueTypeNil;
+    } else if ([self conformsToProtocol:@protocol(WCTColumnCoding)]) {
+        return WCTValueTypeColumnCoding;
+    } else if ([self isKindOfClass:NSString.class]) {
         return WCTValueTypeString;
     } else if ([self isKindOfClass:NSData.class]) {
         return WCTValueTypeData;
     } else if ([self isKindOfClass:NSNumber.class]) {
         return WCTValueTypeNumber;
-    } else if ([self isKindOfClass:NSNull.class]) {
-        return WCTValueTypeNil;
-    } else if ([self conformsToProtocol:@protocol(WCTColumnCoding)]) {
-        return WCTValueTypeColumnCoding;
     } else {
         return WCTValueTypeUnknown;
     }


### PR DESCRIPTION
您好，我在使用wcdb的时候遇见一个问题，我实现了一个类EncString并继承了NSString,同时也实现了WCTColumnCoding 协议，但是在wcdb源码中判断WCTValueType是下面的代码，这样就会造成EncString返回的是WCTValueTypeString类型了，我觉得正确的应该是WCTValueTypeColumnCoding，需要把 if ([self conformsToProtocol:@protocol(WCTColumnCoding)]) 的判断提前。

```
- (WCTValueType)valueType
{
    if ([self isKindOfClass:NSString.class]) {
        return WCTValueTypeString;
    } else if ([self isKindOfClass:NSData.class]) {
        return WCTValueTypeData;
    } else if ([self isKindOfClass:NSNumber.class]) {
        return WCTValueTypeNumber;
    } else if ([self isKindOfClass:NSNull.class]) {
        return WCTValueTypeNil;
    } else if ([self conformsToProtocol:@protocol(WCTColumnCoding)]) {
        return WCTValueTypeColumnCoding;
    } else {
        return WCTValueTypeUnknown;
    }
}
```

```
//这里的archivedWCTValue方法不会走，而且直接对 NSString进行扩展并实现WCTColumnCoding协议也不会走archivedWCTValue，感觉不太合理。
WCTValueType valueType = [value valueType];
if (valueType == WCTValueTypeColumnCoding) {
        value = [(id<WCTColumnCoding>) value archivedWCTValue];
        valueType = [value valueType];
}
```