### PR TITLE
Remove unnecessary manifest code that causes conflicts

### DIFF
--- a/android/room/src/main/AndroidManifest.xml
+++ b/android/room/src/main/AndroidManifest.xml
@@ -1,13 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
-          package="com.tencent.wcdb.room"
->
-
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-    >
-
-    </application>
-
-</manifest>
+<manifest package="com.tencent.wcdb.room"/>


### PR DESCRIPTION
Hi, I am using this library with room and I encountered this failure when I imported `com.tencent.wcdb:room:1.0.8`:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute application@label value=(@string/****) from AndroidManifest.xml:28:9-36
  	is also present at [com.tencent.wcdb:room:1.0.8] AndroidManifest.xml:13:9-41 value=(@string/app_name).
  	Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:25:5-301:19 to override.
```

This PR is just to fix this problem.