### PR TITLE
Fix Create Deep Directory Crash

### DIFF
--- a/src/common/base/FileManager.cpp
+++ b/src/common/base/FileManager.cpp
@@ -346,7 +346,7 @@ Optional<bool> FileManager::fileExists(const UnsafeStringView &file)
 
 Optional<bool> FileManager::directoryExists(const UnsafeStringView &directory)
 {
-    auto result = itemExists(directory);
+    auto result = itemExists(Path::addBackslash(directory));
     if (result.succeed()) {
         bool exists, isDirectory;
         std::tie(exists, isDirectory) = result.value();

--- a/src/common/base/Path.cpp
+++ b/src/common/base/Path.cpp
@@ -55,6 +55,16 @@ StringView addComponent(const UnsafeStringView &base, const UnsafeStringView &co
     return StringView(stream.str());
 }
 
+WCDB::StringView addBackslash(const UnsafeStringView &base)
+{
+    std::ostringstream stream;
+    stream << base;
+    if (base.empty() || base[base.length() - 1] != kPathSeparator) {
+        stream << kPathSeparator;
+    }
+    return StringView(stream.str());
+}
+
 StringView getFileName(const UnsafeStringView &base)
 {
     std::string file = base.data();

--- a/src/common/base/Path.hpp
+++ b/src/common/base/Path.hpp
@@ -34,6 +34,7 @@ namespace Path {
 
 StringView addExtention(const UnsafeStringView &base, const UnsafeStringView &extention);
 StringView addComponent(const UnsafeStringView &base, const UnsafeStringView &component);
+StringView addBackslash(const UnsafeStringView &base);
 StringView getFileName(const UnsafeStringView &base);
 StringView getDirectoryName(const UnsafeStringView &base);
 


### PR DESCRIPTION
## 现象
> Windows平台，当数据库路径为绝对路径，且在磁盘根目录时，**必崩**

```
WCDB::Database database1("E:\\sample.db)");
WCDB::Database database2("E:\\dir1\\dir2\\sample.db");

database1.canOpen(); // 必崩
database2.canOpen(); // 如果dir1和dir2文件夹不存在时，必崩
```

## 原因
判断文件夹是否存在，调用了C语言函数`stat`，该函数处理文件夹路径时，路径结尾需带上分隔符（‘\\’ 或 '/'）。
崩溃的原因是处理上述路径时，会执行如下调用：
```
struct stat s;
stat("E:", &s); // 文件夹路径没有以 '\\' 或 '/' 结尾，函数会返回失败，误判为该文件夹不存在
```
最终导致创建深度文件夹的函数 `FileManager::createDirectoryWithIntermediateDirectories` 进入递归死循环，造成**栈溢出崩溃**。

## 修复方式

在 `Path.hpp` 文件的 `WCDB::Path` 中新增一个函数 `addBackslash`，用于保证路径以 '\\' 或 '/' 结尾：
```

WCDB::StringView addBackslash(const UnsafeStringView &base)
{
    std::ostringstream stream;
    stream << base;
    if (base.empty() || base[base.length() - 1] != kPathSeparator) {
        stream << kPathSeparator;
    }
    return StringView(stream.str());
}
```

在判断文件夹是否存在时，保证文件夹路径以 '\\' 或 '/' 结尾：
```
Optional<bool> FileManager::directoryExists(const UnsafeStringView &directory)
{
    // 下面这行是旧代码：
    // auto result = itemExists(directory);

    // 这是修改后：
    auto result = itemExists(Path::addBackslash(directory));

    // ...
```

这样一来，遇到判断文件夹的时候，会保证文件夹的路径结尾，一定有 '\\' 或 '/'，进入 `stat` 函数就可以正常得到结果。
