### PR TITLE
消除全部的因 switch case 语句没有 default 值返回的编译警告

### DIFF
--- a/src/common/base/WCDBError.hpp
+++ b/src/common/base/WCDBError.hpp
@@ -71,6 +71,8 @@ public:
             return "ERROR";
         case Level::Fatal:
             return "FATAL";
+        default:
+            return "UNKNOWN";
         }
     }
     bool isIgnorable() const;
@@ -178,6 +180,8 @@ public:
             return "Row";
         case Code::Done:
             return "Done";
+        default:
+            return "Unknown";
         }
     }
 

--- a/src/common/core/sqlite/HandleStatement.cpp
+++ b/src/common/core/sqlite/HandleStatement.cpp
@@ -564,6 +564,8 @@ Value HandleStatement::getValue(int index)
         return Value(getText(index));
     case ColumnType::BLOB:
         return Value(getBLOB(index));
+    default:
+        return Value(nullptr);
     }
 }
 

--- a/src/common/winq/extension/Value.cpp
+++ b/src/common/winq/extension/Value.cpp
@@ -88,6 +88,8 @@ bool Value::operator==(const Value &other) const
                m_blobValue.buffer(), other.m_blobValue.buffer(), m_blobValue.size())
                == 0;
     }
+    default:
+        return false;
     }
 }
 
@@ -215,6 +217,8 @@ int64_t Value::intValue() const
     case Type::Null: {
         return 0;
     }
+    default:
+        return 0;
     }
 }
 double Value::floatValue() const
@@ -245,6 +249,8 @@ double Value::floatValue() const
     case Type::Null: {
         return 0;
     }
+    default:
+        return 0;
     }
 }
 
@@ -264,6 +270,8 @@ StringView Value::textValue() const
     case Type::Null: {
         return StringView();
     }
+    default:
+        return StringView();
     }
 }
 
@@ -287,6 +295,8 @@ Data Value::blobValue() const
     case Type::Null: {
         return Data();
     }
+    default:
+        return Data();
     }
 }
 
@@ -307,6 +317,8 @@ bool Value::isEmpty() const
     case Type::BLOB:
         return m_blobValue.size() == 0;
     case Type::Null:
+        return true;
+    default:
         return true;
     }
 }

--- a/src/common/winq/syntax/SyntaxEnum.hpp
+++ b/src/common/winq/syntax/SyntaxEnum.hpp
@@ -43,6 +43,8 @@ constexpr const char* Enum::description(const Syntax::ColumnType& columnType)
         return "TEXT";
     case Syntax::ColumnType::BLOB:
         return "BLOB";
+    default:
+        return "";
     }
 }
 
@@ -58,6 +60,8 @@ constexpr const char* Enum::description(const Syntax::CompoundOperator& compound
         return "INTERSECT";
     case Syntax::CompoundOperator::Except:
         return "EXCEPT";
+    default:
+        return "";
     }
 }
 
@@ -75,6 +79,8 @@ constexpr const char* Enum::description(const Syntax::Conflict& conflict)
         return "ON CONFLICT IGNORE";
     case Syntax::Conflict::Replace:
         return "ON CONFLICT REPLACE";
+    default:
+        return "";
     }
 }
 
@@ -104,6 +110,8 @@ constexpr const char* Enum::description(const Syntax::JoinOperator& joinOperator
         return "NATURAL INNER JOIN";
     case Syntax::JoinOperator::NaturalCrossJoin:
         return "NATURAL CROSS JOIN";
+    default:
+        return "";
     }
 }
 
@@ -115,6 +123,8 @@ constexpr const char* Enum::description(const Syntax::Order& order)
         return "ASC";
     case Syntax::Order::DESC:
         return "DESC";
+    default:
+        return "";
     }
 }
 
@@ -132,6 +142,8 @@ constexpr const char* Enum::description(const Syntax::ConflictAction& action)
         return "OR FAIL";
     case Syntax::ConflictAction::Ignore:
         return "OR IGNORE";
+    default:
+        return "";
     }
 }
 
@@ -145,6 +157,8 @@ constexpr const char* Enum::description(const Syntax::MatchType& match)
         return "FULL";
     case Syntax::MatchType::Partial:
         return "PARTIAL";
+    default:
+        return "";
     }
 }
 

--- a/src/common/winq/syntax/identifier/SyntaxBindParameter.cpp
+++ b/src/common/winq/syntax/identifier/SyntaxBindParameter.cpp
@@ -40,6 +40,8 @@ constexpr const char* Enum::description(const Syntax::BindParameter::Switch& swi
         return "$";
     case Syntax::BindParameter::Switch::AtSign:
         return "@";
+    default:
+        return "";
     }
 }
 

--- a/src/common/winq/syntax/identifier/SyntaxExpression.cpp
+++ b/src/common/winq/syntax/identifier/SyntaxExpression.cpp
@@ -43,6 +43,8 @@ Enum::description(const Syntax::Expression::UnaryOperator& unaryOperator)
         return "NOT";
     case Syntax::Expression::UnaryOperator::Null:
         return "NULL";
+    default:
+        return "";
     }
 }
 
@@ -97,6 +99,8 @@ Enum::description(const Syntax::Expression::BinaryOperator& binaryOperator)
         return "REGEXP";
     case Syntax::Expression::BinaryOperator::Match:
         return "MATCH";
+    default:
+        return "";
     }
 }
 

--- a/src/common/winq/syntax/identifier/SyntaxForeignKeyClause.cpp
+++ b/src/common/winq/syntax/identifier/SyntaxForeignKeyClause.cpp
@@ -52,6 +52,8 @@ constexpr const char* Enum::description(const Syntax::ForeignKeyClause::Switch& 
         return "ON UPDATE RESTRICT";
     case Syntax::ForeignKeyClause::Switch::OnUpdateNoAction:
         return "ON UPDATE NO ACTION";
+    default:
+        return "";
     }
 }
 
@@ -72,6 +74,8 @@ Enum::description(const Syntax::ForeignKeyClause::Deferrable& deferrable)
         return "NOT DEFERRABLE INITIALLY IMMEDIATE";
     case Syntax::ForeignKeyClause::Deferrable::NotDeferrable:
         return "NOT DEFERRABLE";
+    default:
+        return "";
     }
 }
 

--- a/src/common/winq/syntax/identifier/SyntaxFrameSpec.cpp
+++ b/src/common/winq/syntax/identifier/SyntaxFrameSpec.cpp
@@ -36,6 +36,8 @@ constexpr const char* Enum::description(const Syntax::FrameSpec::Switch& switche
         return "RANGE";
     case Syntax::FrameSpec::Switch::Rows:
         return "ROWS";
+    default:
+        return "";
     }
 }
 
@@ -51,6 +53,8 @@ constexpr const char* Enum::description(const Syntax::FrameSpec::FirstEvent& fir
         return "CURRENT ROW";
     case Syntax::FrameSpec::FirstEvent::Following:
         return "FOLLOWING";
+    default:
+        return "";
     }
 }
 
@@ -66,6 +70,8 @@ constexpr const char* Enum::description(const Syntax::FrameSpec::SecondEvent& se
         return "CURRENT ROW";
     case Syntax::FrameSpec::SecondEvent::Following:
         return "FOLLOWING";
+    default:
+        return "";
     }
 }
 

--- a/src/common/winq/syntax/identifier/SyntaxRaiseFunction.cpp
+++ b/src/common/winq/syntax/identifier/SyntaxRaiseFunction.cpp
@@ -40,6 +40,8 @@ constexpr const char* Enum::description(const Syntax::RaiseFunction::Switch& swi
         return "ABORT";
     case Syntax::RaiseFunction::Switch::Fail:
         return "FAIL";
+    default:
+        return "";
     }
 }
 

--- a/src/common/winq/syntax/stmt/SyntaxBeginSTMT.cpp
+++ b/src/common/winq/syntax/stmt/SyntaxBeginSTMT.cpp
@@ -38,6 +38,8 @@ constexpr const char* Enum::description(const Syntax::BeginSTMT::Switch& switche
         return "IMMEDIATE";
     case Syntax::BeginSTMT::Switch::Exclusive:
         return "EXCLUSIVE";
+    default:
+        return "";
     }
 }
 

--- a/src/common/winq/syntax/stmt/SyntaxCreateTriggerSTMT.cpp
+++ b/src/common/winq/syntax/stmt/SyntaxCreateTriggerSTMT.cpp
@@ -38,6 +38,8 @@ constexpr const char* Enum::description(const Syntax::CreateTriggerSTMT::Timing&
         return "AFTER";
     case Syntax::CreateTriggerSTMT::Timing::InsteadOf:
         return "INSTEAD OF";
+    default:
+        return "";
     }
 }
 
@@ -51,6 +53,8 @@ constexpr const char* Enum::description(const Syntax::CreateTriggerSTMT::Event& 
         return "INSERT";
     case Syntax::CreateTriggerSTMT::Event::Update:
         return "UPDATE";
+    default:
+        return "";
     }
 }
 


### PR DESCRIPTION
消除编译警告：`warning c4715 不是所有的控件路径都返回值`