### PR TITLE
Fix link issue for set SWIFT_OBJC_INTEROP_MODE = objcxx in Xcode 15

### DIFF
--- a/src/support/WCDB.modulemap
+++ b/src/support/WCDB.modulemap
@@ -7,7 +7,7 @@ framework module WCDB {
         requires cplusplus17
     }
 
-	module BridgeHeader [extern_c] {
+	module BridgeHeader {
         header "WCTBridgeMacro.h"
         header "WCTBridgeProperty.h"
         header "WCTDeclaration.h"
@@ -23,7 +23,7 @@ framework module WCDB {
 framework module WCDB_Private {
     requires objc
 
-    module BridgeHeader [extern_c] {
+    module BridgeHeader {
         umbrella header "WCDBBridging.h"
         export *
     }

--- a/src/support/WCDBSwift.modulemap
+++ b/src/support/WCDBSwift.modulemap
@@ -7,7 +7,7 @@ framework module WCDBSwift {
 framework module WCDB_Private {
     requires objc
 
-    module BridgeHeader [extern_c] {
+    module BridgeHeader {
         umbrella header "WCDBBridging.h"
         export *
     }


### PR DESCRIPTION
Error message:
Import of C++ module 'Foundation' appears within extern "C" language linkage specification

Details see: https://developer.apple.com/documentation/xcode/identifying-and-addressing-framework-module-issues

import of C++ module ‘ExampleFramework.ExampleSource’ appears within extern “C” language linkage specification, or extern “C” language linkage specification begins here

Avoid including imports inside of extern "C" language linkage specification. Move the include statement outside of the extern "C" scope. Don’t use the [extern_c] attribute in the module map.