### PR TITLE
Support build WCDB.framework from CMake on Apple platform

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -449,6 +449,17 @@ elseif (APPLE AND NOT WCONAN_MODE)
             ${SecurityFramework}
             ${FoundationFrameWork}
             ${z-lib})
+    if (CMAKE_GENERATOR STREQUAL Xcode)
+        target_sources(${TARGET_NAME} PUBLIC ${WCDB_PUBLIC_HEADERS})
+        file(STRINGS "../VERSION" WCDB_VERSION)
+        message(STATUS "Xcode ${TARGET_NAME}.framework version ${WCDB_VERSION}")
+        set_target_properties(${TARGET_NAME} PROPERTIES
+            FRAMEWORK TRUE
+            FRAMEWORK_VERSION ${WCDB_VERSION}
+            MACOSX_FRAMEWORK_IDENTIFIER com.tencent.${TARGET_NAME}
+            PUBLIC_HEADER "${WCDB_PUBLIC_HEADERS}"
+        )
+    endif ()
 elseif (LINUX)
     message(STATUS "---- BUILD FOR LINUX ----")
     target_link_libraries(${TARGET_NAME} PUBLIC


### PR DESCRIPTION
to support #1073 
Now it is able to build WCDB.framework if run command `cmake .. -GXcode`.

Here is a testing sample.
[test_fixed_wcdb_framework.zip](https://github.com/Tencent/wcdb/files/14917587/test_fixed_wcdb_framework.zip)

Run this to build libWCDB.dylib
```
cd test_wcdb_framework
git submodule update --init --recursive
mkdir build && cd build
cmake .. && cmake --build .
./test_dep_wcdb_framework
```
Output
> create wcdb database successful!


Run this to build WCDB.framework
```
cd test_wcdb_framework
git submodule update --init --recursive
mkdir buildx && cd buildx
cmake .. -GXcode && cmake --build .
./Debug/test_dep_wcdb_framework
```
Output
> create wcdb database successful!

After running `test_dep_wcdb_framework`, if the result is correct, you can see that the database file `sample.db` has been created.
Also you can use `otool -l ./Debug/test_dep_wcdb_framework` to see dependent libraries.
Should be
> ...
> Load command 13
>           cmd LC_LOAD_DYLIB
>       cmdsize 72
>          name @rpath/WCDB.framework/Versions/2.1.2/WCDB (offset 24)
>    time stamp 2 Thu Jan  1 08:00:02 1970
>       current version 0.0.0
> compatibility version 0.0.0
> ...