### PR TITLE
设置线程名称的函数，增加对Windows平台的支持

### DIFF
--- a/src/common/base/Thread.cpp
+++ b/src/common/base/Thread.cpp
@@ -151,6 +151,36 @@ void Thread::setName(const UnsafeStringView& name)
         Notifier::shared().notify(error);
         SharedThreadedErrorProne::setThreadedError(std::move(error));
     }
+#else
+    // See also: http://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
+    WCTAssert(name.length() <= 16) // Thread name is limited to 16 bytes
+    char buffer[maxLengthOfAllowedThreadName()];
+    memset(buffer, 0, maxLengthOfAllowedThreadName());
+    memcpy(buffer, name.data(), name.length());
+    const DWORD MS_VC_EXCEPTION = 0x406D1388;
+
+#pragma pack(push, 8)
+    typedef struct tagTHREADNAME_INFO {
+        DWORD dwType;     // Must be 0x1000.
+        LPCSTR szName;    // Pointer to name (in user addr space).
+        DWORD dwThreadID; // Thread ID (-1=caller thread).
+        DWORD dwFlags;    // Reserved for future use, must be zero.
+    } THREADNAME_INFO;
+#pragma pack(pop)
+
+    THREADNAME_INFO info;
+    info.dwType = 0x1000;
+    info.szName = buffer;
+    info.dwThreadID = GetCurrentThreadId();
+    info.dwFlags = 0;
+
+#pragma warning(push)
+#pragma warning(disable : 6320 6322)
+    __try {
+        RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*) &info);
+    } __except (EXCEPTION_CONTINUE_EXECUTION) {
+    }
+#pragma warning(pop)
 #endif
 }
 

--- a/src/common/utility/Exiting.cpp
+++ b/src/common/utility/Exiting.cpp
@@ -28,8 +28,8 @@
 #include <atomic>
 #include <stdlib.h>
 #ifdef _WIN32
-#include <VersionHelpers.h>
 #include <windows.h>
+#include <VersionHelpers.h>
 #endif
 
 namespace WCDB {


### PR DESCRIPTION
摘至：
1. http://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
2. https://github.com/pocoproject/poco/blob/main/Foundation/src/Thread_WIN32.cpp

支持Windows XP及以上系统