### PR TITLE
HandlePool Read-Write Mixing Causes Handle Recycling Issue

### DIFF
--- a/src/java/main/src/main/java/com/tencent/wcdb/core/HandleOperation.java
+++ b/src/java/main/src/main/java/com/tencent/wcdb/core/HandleOperation.java
@@ -1096,8 +1096,17 @@ public abstract class HandleOperation extends CppObject {
      * @throws WCDBException if any error occurs.
      */
     public boolean isInTransaction() throws WCDBException {
-        Handle handle = getHandle(false);
-        return Handle.isInTransaction(handle.getCppHandle());
+        Handle handle = null;
+        boolean res;
+        try {
+            handle = getHandle(false);
+            res = Handle.isInTransaction(handle.getCppHandle());
+        } finally {
+            if (handle != null && autoInvalidateHandle()) {
+                handle.invalidate();
+            }
+        }
+        return res;
     }
 
     /**


### PR DESCRIPTION
#### Key Point
You should explicitly release the handle after use.
![image](https://github.com/user-attachments/assets/c395faa2-2f4c-4c26-a76e-fa4f73b035f0)


#### Description

In the implementation of HandlePool, the flowOut function does not distinguish between writeHint for read and write operations, leading to the reuse of the same Handle for both. This can cause the reference count (referencedHandle.reference) to never reach zero in certain scenarios, preventing the recycling of the Handle.


#### Steps to Reproduce

I created a minimal demo to reproduce this issue: https://github.com/Tencent/wcdb/pull/1290

in short, it's a simple demo just does the only three things:

1. Begin a transaction (beginTransaction).
2. Perform multiple read and write operations within the transaction.
3. Observe that the reference count keeps increasing, and the recycling logic in flowBack is never triggered.

In this scenario, the Handle reused in HandlePool::flowOut cannot be released because the reference count never decreases to zero. (sometimes would be negative value)

![image](https://github.com/user-attachments/assets/126b2080-5e5e-4d48-a6c7-01ace5279ffc)

