### PR TITLE
[feature] rename libWCDB.so to libwcdb2.so to support case-sensitive …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,7 +295,7 @@ else ()
 endif ()
 
 if (NOT DEFINED WCONAN_LIB_NAME)
-    set(WCONAN_LIB_NAME "WCDB")
+    set(WCONAN_LIB_NAME "wcdb2")
 endif ()
 
 if (NOT DEFINED TARGET_NAME)

--- a/src/java/main/src/main/cpp/CMakeLists.txt
+++ b/src/java/main/src/main/cpp/CMakeLists.txt
@@ -12,7 +12,7 @@ project(WCDB_Android)
 
 include(../../../../../utility.cmake)
 
-set(TARGET_NAME "WCDB")
+set(TARGET_NAME "wcdb2")
 set(WCDB_BRIDGE ON)
 set(SKIP_WCONAN ON)
 set(BUILD_SHARED_LIBS ON)

--- a/src/java/main/src/main/java/com/tencent/wcdb/base/CppObject.java
+++ b/src/java/main/src/main/java/com/tencent/wcdb/base/CppObject.java
@@ -24,7 +24,7 @@ package com.tencent.wcdb.base;
 
 public class CppObject implements CppObjectConvertible {
     static {
-        System.loadLibrary("WCDB");
+        System.loadLibrary("wcdb2");
     }
 
     @Override


### PR DESCRIPTION
**Problem:**  
On macOS (with default case-insensitive APFS), `libwcdb.so` and `libWCDB.so` are treated as the same file, which may cause conflicts during compilation or runtime.

**Expected Behavior:**  
The library should work correctly even on case-insensitive filesystems (e.g., by ensuring unique filenames or documenting the requirement for a case-sensitive environment).