### PR TITLE
fix: initialize JavaVM pointer before calling addMigrationSource

### DIFF
--- a/src/java/main/src/main/cpp/core/DatabaseJNI.c
+++ b/src/java/main/src/main/cpp/core/DatabaseJNI.c
@@ -640,6 +640,7 @@ void WCDBJNIDatabaseClassMethod(
 addMigrationSource, jlong self, jstring sourcePath, jbyteArray cipherKey, jobject filter)
 {
     WCDBJNIBridgeStruct(CPPDatabase, self);
+    WCDBJNITryGetVM;
     WCDBJNICreateGlobalRel(filter);
     WCDBJNIGetString(sourcePath);
     WCDBJNIGetByteArrayCritical(cipherKey);


### PR DESCRIPTION
This PR fixes a null pointer crash in WCDBJNIDatabaseFilterMigrate caused by accessing uninitialized g_vm in WCDBJNITryGetEnvOr(return). 