### PR TITLE
Fix build errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -363,7 +363,7 @@ else ()
     # enable lto and no-plt
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto -fno-plt")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -fno-plt")
-`
+
     if (LINUX)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -pthread")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pthread")

--- a/src/common/base/FileManager.cpp
+++ b/src/common/base/FileManager.cpp
@@ -167,7 +167,7 @@ bool FileManager::createFileHardLink(const UnsafeStringView &from, const UnsafeS
     if (CreateHardLinkW(GetPathString(to), GetPathString(from), NULL)) {
         return true;
     }
-    if (CopyFile(GetPathString(from), GetPathString(to), true)) {
+    if (CopyFileW(GetPathString(from), GetPathString(to), TRUE)) {
         return true;
     }
     setThreadedWinError(to);

--- a/src/common/core/fts/AutoMergeFTSIndexConfig.hpp
+++ b/src/common/core/fts/AutoMergeFTSIndexConfig.hpp
@@ -25,6 +25,8 @@
 #include "Config.hpp"
 #include "Lock.hpp"
 
+#include <vector>
+
 namespace WCDB {
 
 class AutoMergeFTSIndexOperator {


### PR DESCRIPTION

This pull request includes several small improvements and fixes across the codebase, mainly focusing on build configuration, Windows file operations, and header file dependencies.

Build system and configuration:

* Fixed formatting in `src/CMakeLists.txt` by removing an extraneous backtick character, ensuring cleaner and more correct CMake configuration.

Platform-specific code improvements:

* In `FileManager.cpp`, updated the fallback file copy operation to use the wide-character version `CopyFileW` and the correct boolean constant `TRUE`, improving compatibility and correctness on Windows systems.

Header file dependencies:

* Added the missing `<vector>` include to `AutoMergeFTSIndexConfig.hpp`, ensuring that the file has access to the standard vector container.