### PR TITLE
Fix WCDB.objc.podspec missing headers for C++ modules support

### DIFF
--- a/WCDB.objc.podspec
+++ b/WCDB.objc.podspec
@@ -90,7 +90,10 @@ Pod::Spec.new do |wcdb|
 	"src/common/base/WCDBError.hpp", 
 	"src/common/base/Data.hpp", 
 	"src/common/base/UnsafeData.hpp", 
-	"src/common/base/MemberPointer.hpp"
+	"src/common/base/MemberPointer.hpp",
+	"src/common/base/Assertion.hpp",
+	"src/common/base/Console.hpp",
+	"src/common/utility/Enum.hpp"
   ]
   wcdb.source_files  = [
   	"src/common/**/*.{h,hpp,c,cpp}", 


### PR DESCRIPTION
### Background
When building WCDB with Objective-C++ and Swift mixed projects,
the generated `-Swift.h` uses `@import`, which requires modules
support (`-fmodules -fcxx-modules`).  

However, WCDB.objc.podspec did not expose several required headers
as public, causing module map to be incomplete and build to fail.

### Changes
- Added missing headers to `public_header_files` in podspec
- Ensures WCDB works correctly with `-fcxx-modules`

### Impact
- Fixes build errors in ObjC++ projects using WCDB and Swift
- No behavior changes for existing ObjC-only users


Related issue: https://github.com/Tencent/wcdb/issues/979