### PR TITLE
暴露sqlite3_set_auxdata函数给自定义ScalarFunction用

### DIFF
--- a/src/common/core/function/scalar/ScalarFunctionModule.cpp
+++ b/src/common/core/function/scalar/ScalarFunctionModule.cpp
@@ -168,6 +168,22 @@ void ScalarFunctionAPI::setErrorResult(int code, const UnsafeStringView &msg)
     sqlite3_result_error_code((sqlite3_context *) m_sqliteContext, code);
 }
 
+void ScalarFunctionAPI::setAuxData(void *data, void (*destroy)(void *), int index)
+{
+    if (!m_sqliteContext) {
+        return;
+    }
+    sqlite3_set_auxdata((sqlite3_context *) m_sqliteContext, 0, data, destroy);
+}
+
+void *ScalarFunctionAPI::getAuxData(int index)
+{
+    if (!m_sqliteContext) {
+        return nullptr;
+    }
+    return sqlite3_get_auxdata((sqlite3_context *) m_sqliteContext, index);
+}
+
 void *ScalarFunctionAPI::getUserData() const
 {
     if (!m_sqliteContext) {

--- a/src/common/core/function/scalar/ScalarFunctionModule.hpp
+++ b/src/common/core/function/scalar/ScalarFunctionModule.hpp
@@ -59,6 +59,10 @@ public:
     void setErrorResult(Error::Code code, const UnsafeStringView& msg);
     void setErrorResult(int code, const UnsafeStringView& msg);
 
+    // Access Auxiliary Data
+    void setAuxData(void* data, void (*destroy)(void*), int index = 0);
+    void* getAuxData(int index = 0);
+
 protected:
     ScalarFunctionAPI(SQLiteContext* ctx, SQLiteValue** values, int valueNum);
 


### PR DESCRIPTION
该接口的使用场景举例：**注册正则表达式函数**

```cpp
class MyRegexp : public WCDB::AbstractScalarFunctionObject {
public:
    MyRegexp(void* userContext, WCDB::ScalarFunctionAPI& apiObj)
        : WCDB::AbstractScalarFunctionObject(userContext, apiObj)
    {}

    virtual void process(WCDB::ScalarFunctionAPI& apiObj) override
    {
        auto text = apiObj.getTextValue(1);
        if (text.empty()) {
            return;
        }

        auto rx = (boost::regex*)apiObj.getAuxData(); // 3. 获取已构建好的正则表达式句柄
        if (!rx) {
            auto pattern = apiObj.getTextValue(0);
            if (pattern.empty()) {
                return;
            }

            rx = createRegexpHandle(pattern.data()); // 1. 构建正则表达式句柄
            if (!rx) {
                apiObj.setErrorResult(WCDB::Error::Code::Error, "Failed to create regex handle");
                return;
            }

            apiObj.setAuxData(rx, &destroyRegexpHandle); // 2. 存储已构建好的正则表达式句柄
        }

        boost::cmatch cm;
        if (boost::regex_search(text.data(), text.data() + text.size(), cm, *rx)) {
            apiObj.setIntResult(1);
        }
        else {
            apiObj.setIntResult(0);
        }
    }

private:
    static boost::regex* createRegexpHandle(const char* pattern)
    {
        return new boost::regex(pattern);
    }

    static void destroyRegexpHandle(void* p)
    {
        boost::regex* rx = (boost::regex*)p;
        delete rx;
    }
};
```