### PR TITLE
fix: resolve Tag.hpp compilation error on Xcode 26.4

### DIFF
--- a/src/common/core/Tag.hpp
+++ b/src/common/core/Tag.hpp
@@ -32,8 +32,12 @@ namespace WCDB {
 
 // Custom trait to identify integer-like types
 // (replaces illegal std::is_integral specialization for Tag)
+// Uses remove_cv to preserve const/volatile semantics like std::is_integral
 template<typename T>
-struct IsInteger : public std::is_integral<T> {};
+struct IsIntegerImpl : public std::is_integral<T> {};
+
+template<typename T>
+struct IsInteger : public IsIntegerImpl<typename std::remove_cv<T>::type> {};
 
 class WCDB_API Tag final {
 public:
@@ -54,6 +58,6 @@ private:
 };
 
 template<>
-struct IsInteger<Tag> : public std::true_type {};
+struct IsIntegerImpl<Tag> : public std::true_type {};
 
 } // namespace WCDB

--- a/src/common/core/Tag.hpp
+++ b/src/common/core/Tag.hpp
@@ -30,6 +30,11 @@
 
 namespace WCDB {
 
+// Custom trait to identify integer-like types
+// (replaces illegal std::is_integral specialization for Tag)
+template<typename T>
+struct IsInteger : public std::is_integral<T> {};
+
 class WCDB_API Tag final {
 public:
     static const Tag& invalid();
@@ -47,5 +52,8 @@ private:
     Tag(const std::nullptr_t&);
     long m_value;
 };
+
+template<>
+struct IsInteger<Tag> : public std::true_type {};
 
 } // namespace WCDB

--- a/src/common/winq/extension/ColumnType.hpp
+++ b/src/common/winq/extension/ColumnType.hpp
@@ -28,6 +28,7 @@
 #include "StringView.hpp"
 #include "Syntax.h"
 #include "SyntaxForwardDeclaration.h"
+#include "Tag.hpp"
 #include <cstdint>
 #include <type_traits>
 #include <vector>
@@ -159,7 +160,7 @@ public:
 
 //Integer
 template<typename T>
-struct ColumnIsIntegerType<T, typename std::enable_if<(std::is_integral<T>::value || std::is_enum<T>::value)>::type>
+struct ColumnIsIntegerType<T, typename std::enable_if<(WCDB::IsInteger<T>::value || std::is_enum<T>::value)>::type>
 : public std::true_type {
 public:
     static ColumnTypeInfo<ColumnType::Integer>::UnderlyingType

--- a/src/common/winq/extension/ConvertibleImplementation.hpp
+++ b/src/common/winq/extension/ConvertibleImplementation.hpp
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "Convertible.hpp"
+#include "Tag.hpp"
 #include "Value.hpp"
 
 namespace WCDB {
@@ -63,7 +64,7 @@ struct SafeUnderlyingType<T, false> {};
 template<typename T, typename Enable = void>
 struct Is64BitUnsignedInteger : public std::false_type {};
 template<typename T>
-struct Is64BitUnsignedInteger<T, typename std::enable_if<std::is_integral<T>::value && (sizeof(T) > 4) && std::is_unsigned<T>::value>::type>
+struct Is64BitUnsignedInteger<T, typename std::enable_if<WCDB::IsInteger<T>::value && (sizeof(T) > 4) && std::is_unsigned<T>::value>::type>
 : public std::true_type {};
 
 template<typename T, typename Enable = void>
@@ -75,7 +76,7 @@ struct Is64BitUnsignedEnum<T, typename std::enable_if<std::is_enum<T>::value && 
 template<typename T>
 class LiteralValueConvertible<
 T, // 32-bit-integer/enum or 64-bit-signed-integer/enum
-typename std::enable_if<(std::is_integral<T>::value || std::is_enum<T>::value)
+typename std::enable_if<(WCDB::IsInteger<T>::value || std::is_enum<T>::value)
                         && !Is64BitUnsignedInteger<T>::value && !Is64BitUnsignedEnum<T>::value>::type>
 final : public std::true_type {
 public:


### PR DESCRIPTION
This PR was implemented by Claude Opus 4.6 and reviewed by GPT-5.4.

## Summary

Fixes the `Tag.hpp` build error on Xcode 26.4:

`'is_integral' cannot be specialized: Users are not allowed to specialize this
standard library entity`

## Changes

- replace the illegal `std::is_integral` specialization for `WCDB::Tag`
- introduce `WCDB::IsInteger` for integer-like type detection
- update related template dispatch to use the new trait
- preserve `const`/`volatile` behavior for `Tag`